### PR TITLE
chore(docker ci): Fix the docker container ci builds

### DIFF
--- a/.github/workflows/launchpad_docker.yml
+++ b/.github/workflows/launchpad_docker.yml
@@ -66,7 +66,7 @@ jobs:
             # Pull App version from file
             VAPP=$(awk -F ' = ' \
               '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2) }' \
-              "${GITHUB_WORKSPACE}/applications/tari_base_node/Cargo.toml")
+              "${GITHUB_WORKSPACE}/tari/applications/tari_base_node/Cargo.toml")
 
             VBRANCH=$(echo ${GITHUB_REF#refs/heads/})
             VSHA_SHORT=$(git rev-parse --short HEAD)
@@ -98,7 +98,7 @@ jobs:
             echo ::set-output name=dockercontext::./
           else
             DOCKERFILE=${IMAGE}.Dockerfile
-            DOCKERCONTEXT=./applications/launchpad/docker_rig/
+            DOCKERCONTEXT=./docker_rig/
 
             # Pull the docker image version TAG from service dockerfile
             SUBTAG=$(awk -v search="^ARG ${IMAGE^^}?_VERSION=" -F '=' '$0 ~ search \
@@ -138,7 +138,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ${{ steps.environments.outputs.dockercontext }}
-          file: ./applications/launchpad/docker_rig/${{ steps.environments.outputs.dockerfile }}
+          file: ./docker_rig/${{ steps.environments.outputs.dockerfile }}
           platforms: linux/arm64, linux/amd64
           push: true
           cache-from: type=gha

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tari"]
+	path = tari
+	url = git@github.com:tari-project/tari.git

--- a/build_images.sh
+++ b/build_images.sh
@@ -92,7 +92,7 @@ build_tari_image_json() {
   export $(jq --arg jsonVar "$1" -r '. [] | select(."image_name"==$jsonVar)
     | to_entries[] | .key + "=" + .value' tarisuite.json)
   build_tari_image $image_name \
-    "$TL_VERSION_LONG" ./../.. \
+    "$TL_VERSION_LONG" ./ \
     $app_name $app_exec
 }
 
@@ -139,7 +139,7 @@ fi
 # Version refers to the base_node, wallet, etc.
 #  applications/tari_app_utilities/Cargo.toml
 TL_VERSION=${TL_VERSION:-$(awk -F ' = ' '$1 ~ /version/ \
-  { gsub(/["]/, "", $2); printf("%s",$2) }' "../tari_base_node/Cargo.toml")}
+  { gsub(/["]/, "", $2); printf("%s",$2) }' "./tari/applications/tari_base_node/Cargo.toml")}
 
 # Default build options - general x86-64 / AMD64
 TBN_ARCH=${TBN_ARCH:-x86-64}

--- a/docker_rig/tarilabs.Dockerfile
+++ b/docker_rig/tarilabs.Dockerfile
@@ -62,18 +62,18 @@ RUN if [ -n "${RUST_TOOLCHAIN}" ]; then \
 
 WORKDIR /tari
 
-ADD Cargo.toml .
-ADD Cargo.lock .
-ADD rust-toolchain.toml .
-ADD applications applications
-ADD base_layer base_layer
-ADD clients clients
-ADD common common
-ADD common_sqlite common_sqlite
-ADD comms comms
-ADD infrastructure infrastructure
-ADD dan_layer dan_layer
-ADD meta meta
+ADD tari/Cargo.toml .
+ADD tari/Cargo.lock .
+ADD tari/rust-toolchain.toml .
+ADD tari/applications applications
+ADD tari/base_layer base_layer
+ADD tari/clients clients
+ADD tari/common common
+ADD tari/common_sqlite common_sqlite
+ADD tari/comms comms
+ADD tari/infrastructure infrastructure
+ADD tari/dan_layer dan_layer
+ADD tari/meta meta
 
 RUN --mount=type=cache,id=rust-git-${TARGETOS}-${TARGETARCH}${TARGETVARIANT},sharing=locked,target=/home/rust/.cargo/git \
     --mount=type=cache,id=rust-home-registry-${TARGETOS}-${TARGETARCH}${TARGETVARIANT},sharing=locked,target=/home/rust/.cargo/registry \
@@ -158,7 +158,7 @@ RUN if [ "${APP_NAME}" = "base_node" ] ; then \
 USER tari
 
 COPY --from=builder /tari/$APP_EXEC /usr/bin/
-COPY applications/launchpad/docker_rig/start_tari_app.sh /usr/bin/start_tari_app.sh
+ADD docker_rig/start_tari_app.sh /usr/bin/start_tari_app.sh
 
 ENTRYPOINT [ "start_tari_app.sh", "-c", "/var/tari/config/config.toml", "-b", "/var/tari/${APP_NAME}" ]
 # CMD [ "--non-interactive-mode" ]

--- a/hosted-dual.env
+++ b/hosted-dual.env
@@ -20,7 +20,7 @@ export TL_TAG_BUILD_OPTS="buildx build --platform linux/amd64,linux/arm64 --push
 # Pull App version from file
 VAPP=$(awk -F ' = ' \
     '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2) }' \
-    "../tari_base_node/Cargo.toml")
+    "./tari/applications/tari_base_node/Cargo.toml")
 
 VBRANCH=$(git branch --show-current)
 VSHA_SHORT=$(git rev-parse --short HEAD)


### PR DESCRIPTION
Description
---
Get docker builds running again locally, and hopefully via CI

Motivation and Context
---
Launchpad was expected to be nested within the Tari repo, and to build the tari docker containers we need to instead nest tari in launchpad via submodule. Not needed for development, but required for container building.

How Has This Been Tested?
---
CI will bring us the news of green.
