### PR TITLE
fix: define a longer container update reminder

### DIFF
--- a/gui-react/src/config/app.ts
+++ b/gui-react/src/config/app.ts
@@ -1,6 +1,6 @@
 export default {
   // If user dismisses downloading latest Docker image via TBot,
   // after what time we can ask user again? [ms]
-  dockerDownloadDismissValidFor: 30 * 1000, // 30 sec
+  dockerDownloadDismissValidFor: 24 * 60 * 60 * 1000, // [ms] // 24 hours
   dockerNewImagesCheckInterval: 600000, // [ms] // @TODO - change to 60000 - using larger until updated field is not fixed
 }


### PR DESCRIPTION
Description
---
The dismissal was only valid for 5 minutes before and was slowly driving me insane. Set it to 24 hours. No need to hassle someone multiple times daily.

How Has This Been Tested?
---
Manually