### PR TITLE
fix: tor container thinking it's offline

### DIFF
--- a/docker_rig/tor.Dockerfile
+++ b/docker_rig/tor.Dockerfile
@@ -43,9 +43,14 @@ VOLUME ["/etc/tor", "/var/lib/tor"]
 #
 # grep gets the output of curl and looks for first occurence of the string 'Congratulations',
 # exits with 0 if found and 1 otherwise. Nothing is printed to stdout during this command.
-HEALTHCHECK --interval=120s --timeout=30s --start-period=60s --retries=5 \
-            CMD curl --silent --location --socks5-hostname localhost:9050 https://check.torproject.org/?lang=en_US | \
-            grep -qm1 Congratulations
+
+# Currently this healthcheck is problematic and may need very long timeout periods to operate. The endpoint we're using
+# isn't controlled by us and sometimes takes up to 45seconds to return, othertimes it gets denied by cloudflare.
+# Additionally the HEALTHCHECK emits docker events that launchpad doesn't currently handle well, and will cause the
+# container to show as offline.
+# HEALTHCHECK --interval=120s --timeout=30s --start-period=60s --retries=5 \
+#             CMD curl --silent --location --socks5-hostname localhost:9050 https://check.torproject.org/?lang=en_US | \
+#             grep -qm1 Congratulations
 
 USER tor
 ENTRYPOINT ["/usr/bin/tor"]


### PR DESCRIPTION
Description
---
Turn off the Tor container healthcheck.

Fixes #97 in the most simplistic manner.

Motivation and Context
---
When the healthcheck moved from state "Starting" to "Healthy" it caused launchpad to become confused and believe the container had shut off. It's the only container that uses a healthcheck so it's the only container that intermittantly thinks it's offline.

How Has This Been Tested?
---
Rebuilt the tor container locally and tested.