### PR TITLE
fix: comment out image update status

### DIFF
--- a/gui-react/src/components/DockerImagesList/index.tsx
+++ b/gui-react/src/components/DockerImagesList/index.tsx
@@ -116,7 +116,7 @@ const DockerImagesList = ({
             )}
             {!dockerImage.updated && !dockerImage.pending && (
               <DockerStatusWrapper>
-                {dockerImage.error ? (
+                {dockerImage.error && (
                   <ErrorWrapper
                     onClick={() => setErrorInAlert(dockerImage.error)}
                   >
@@ -127,9 +127,10 @@ const DockerImagesList = ({
                       {dockerImage.error}
                     </Text>
                   </ErrorWrapper>
-                ) : (
-                  <Tag type='warning'>{t.docker.newerVersion}</Tag>
                 )}
+                {/*
+                  <Tag type='warning'>{t.docker.newerVersion}</Tag>
+                */}
                 <Button
                   variant='button-in-text'
                   type='link'

--- a/gui-react/src/useCheckDockerImages.ts
+++ b/gui-react/src/useCheckDockerImages.ts
@@ -28,10 +28,10 @@ const checkImages = async (serviceSettings: any, dispatch: AppDispatch) => {
       settings: serviceSettings,
     })
 
-    const outdated = result.imageInfo.filter(i => !i.updated)
+    /* const outdated = result.imageInfo.filter(i => !i.updated)
     outdated.map(i => {
       dispatch(dockerImagesActions.pushToTBotQueue(i))
-    })
+    }) */
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(err)


### PR DESCRIPTION
Description
---
This just comments out the image update notifications in app because we can't consistently tell if an image has been updated yet and right now it's designed to always just say there's an updated image.

Motivation and Context
---
See https://github.com/tari-project/tari-launchpad/issues/104

How Has This Been Tested?
---
Manually
