### PR TITLE
fix: update tbot background when expert view is toggled

### DIFF
--- a/gui-react/src/components/TBot/TBotPrompt/index.tsx
+++ b/gui-react/src/components/TBot/TBotPrompt/index.tsx
@@ -301,7 +301,7 @@ const TBotPrompt = ({
         </MessageBox>
       )
     })
-  }, [messages, count]) as ReactNode
+  }, [messages, count, onDarkBg]) as ReactNode
 
   if (!open) {
     return null


### PR DESCRIPTION
Description
---
The background colour on TBot that had previously been opened, will now switch from light to dark mode when expert mode is toggled.

Motivation and Context
---
If TBot is open while expert view is on, the background on the messages is in dark mode. If expert mode is then switched off, the background remains dark until a new message appears, which then turns the background back to light mode.
Issue #120 

How Has This Been Tested?
---
Manually
