### PR TITLE
fix(dockerfile): variable naming in the path

### DIFF
--- a/docker_rig/tarilabs.Dockerfile
+++ b/docker_rig/tarilabs.Dockerfile
@@ -153,5 +153,5 @@ USER tari
 COPY --from=builder /tari/$APP_EXEC /usr/bin/
 COPY buildtools/docker_rig/start_tari_app.sh /usr/bin/start_tari_app.sh
 
-ENTRYPOINT [ "start_tari_app.sh", "-c", "/var/tari/config/config.toml", "-b", "/var/tari/${APP_NAME}" ]
+ENTRYPOINT [ "start_tari_app.sh", "-c", "/var/tari/config/config.toml", "-b", "/var/tari/$APP_NAME" ]
 # CMD [ "--non-interactive-mode" ]


### PR DESCRIPTION
Description
---
A small fix to adjust the paths files are put in.

Motivation and Context
---
![image](https://user-images.githubusercontent.com/179134/188579266-5b40e9a2-418b-4796-a106-6baa3fa454ac.png)


How Has This Been Tested?
---
Manually building the base node container locally and initializing it.
