### PR TITLE
fix: dismiss container messages with x

### DIFF
--- a/gui-react/src/components/TBot/TBotPrompt/index.tsx
+++ b/gui-react/src/components/TBot/TBotPrompt/index.tsx
@@ -9,6 +9,9 @@ import { useAppDispatch, useAppSelector } from '../../../store/hooks'
 import { tbotactions } from '../../../store/tbot'
 import { TBotMessage, TBotPromptProps } from './types'
 
+import { selectDockerTBotQueue } from '../../../store/dockerImages/selectors'
+import { actions as dockerImagesActions } from '../../../store/dockerImages'
+
 import {
   ContentRow,
   PromptContainer,
@@ -30,6 +33,7 @@ import { ChatDotsLight, ChatDotsDark } from '../DotsComponent'
 import MessageBox from './MessageBox'
 import ProgressIndicator from '../../Onboarding/ProgressIndicator'
 import { selectTheme } from '../../../store/app/selectors'
+import { convertToObject } from 'typescript'
 
 // The default time between rendering messages
 const WAIT_TIME = 2800
@@ -112,8 +116,19 @@ const TBotPrompt = ({
     }
   }
 
+  const dockerImagesQueue = useAppSelector(selectDockerTBotQueue)
+  const dockerImage = useMemo(() => dockerImagesQueue[0], [dockerImagesQueue])
+
   const close = () => {
-    return dispatch(tbotactions.close())
+    dispatch(tbotactions.close())
+    if (dockerImage) {
+      dispatch(
+        dockerImagesActions.removeFromTBotQueue({
+          image: dockerImage,
+          dismiss: true,
+        }),
+      )
+    }
   }
 
   const needToShowFadeOutSection = async () => {

--- a/gui-react/src/components/TBot/TBotPrompt/index.tsx
+++ b/gui-react/src/components/TBot/TBotPrompt/index.tsx
@@ -33,7 +33,6 @@ import { ChatDotsLight, ChatDotsDark } from '../DotsComponent'
 import MessageBox from './MessageBox'
 import ProgressIndicator from '../../Onboarding/ProgressIndicator'
 import { selectTheme } from '../../../store/app/selectors'
-import { convertToObject } from 'typescript'
 
 // The default time between rendering messages
 const WAIT_TIME = 2800


### PR DESCRIPTION
Description
---
TBot container messages could not be dismissed by pressing "x".
There was an extra action specific to the docker images that needed to be dispatched when pressing on the x to remove them from the TBot message queue.

Motivation and Context
---
Fixes issue #112  

How Has This Been Tested?
---
Manually
