### PR TITLE
feat: use the local base node

### DIFF
--- a/backend/src/docker/mod.rs
+++ b/backend/src/docker/mod.rs
@@ -82,7 +82,7 @@ pub async fn try_create_container(
     docker: Docker,
 ) -> Result<ContainerCreateResponse, DockerWrapperError> {
     debug!("{} has configuration object: {:#?}", fully_qualified_image_name, config);
-    let args = config.command(image);
+    let args = config.command(image).await;
     let envars = config.environment(image);
     let volumes = config.volumes(image);
     let ports = config.ports(image);

--- a/backend/src/docker/settings.rs
+++ b/backend/src/docker/settings.rs
@@ -246,10 +246,10 @@ impl LaunchpadConfig {
     }
 
     /// Return the command line arguments we want for the given container execution.
-    pub fn command(&self, image_type: ImageType) -> Vec<String> {
+    pub async fn command(&self, image_type: ImageType) -> Vec<String> {
         match image_type {
             ImageType::BaseNode => self.base_node_cmd(),
-            ImageType::Wallet => self.wallet_cmd(),
+            ImageType::Wallet => self.wallet_cmd().await,
             ImageType::XmRig => self.xmrig_cmd(),
             ImageType::Sha3Miner => self.miner_cmd(),
             ImageType::MmProxy => self.mm_proxy_cmd(),
@@ -288,7 +288,7 @@ impl LaunchpadConfig {
         args.into_iter().map(String::from).collect()
     }
 
-    fn wallet_cmd(&self) -> Vec<String> {
+    async fn wallet_cmd(&self) -> Vec<String> {
         let args = vec![
             "--log-config=/var/tari/config/log4rs.yml",
             "--seed-words-file=/var/tari/config/seed_words.txt",

--- a/backend/src/grpc/model.rs
+++ b/backend/src/grpc/model.rs
@@ -112,8 +112,8 @@ pub enum SyncType {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BaseNodeIdentity {
-    public_key: Vec<u8>,
-    public_address: String,
+    pub public_key: Vec<u8>,
+    pub public_address: String,
     node_id: Vec<u8>,
     emoji_id: String,
 }


### PR DESCRIPTION
Description
---
A simple update to the wallet settings command to use the local base node when starting up.

Motivation and Context
---
We start a base node but there's no setting pane or _easy_ way for a user to utilize the node they're running. This PR updates the start command so the wallet actually utilizes the local base node.

How Has This Been Tested?
---
Manually

Closes #127 