### PR TITLE
fix: remove the skip sync button

### DIFF
--- a/gui-react/src/containers/Onboarding/index.tsx
+++ b/gui-react/src/containers/Onboarding/index.tsx
@@ -179,17 +179,6 @@ const OnboardingContainer = () => {
 
   return (
     <StyledOnboardingContainer>
-      <Button
-        variant='secondary'
-        onClick={() => dispatch(setOnboardingComplete(true))}
-        style={{
-          position: 'absolute',
-          bottom: 40,
-          left: 40,
-        }}
-      >
-        <Text type='smallHeavy'>{t.onboarding.actions.skipOnboarding}</Text>
-      </Button>
       <TBotPrompt
         open={true}
         messages={messages}


### PR DESCRIPTION
Description
---
If a user skips the blockchain syncing then they cannot use the app. So lets remove the skip button and force the wait to sync.

Motivation and Context
---
No sync makes for a broken experience.

How Has This Been Tested?
---
Manually

Closes #107 