### PR TITLE
fix: remove remaining esme shorthand

### DIFF
--- a/backend/src/docker/models.rs
+++ b/backend/src/docker/models.rs
@@ -142,7 +142,6 @@ impl From<LogOutput> for LogMessage {
 #[derive(Serialize, Debug, Deserialize, Clone, Copy)]
 pub enum TariNetwork {
     Dibbler,
-    Esme,
     Esmeralda,
     Igor,
     Mainnet,
@@ -152,7 +151,6 @@ impl TariNetwork {
     pub fn lower_case(self) -> &'static str {
         match self {
             Self::Dibbler => "dibbler",
-            Self::Esme => "esmeralda",
             Self::Esmeralda => "esmeralda",
             Self::Igor => "igor",
             Self::Mainnet => "mainnet",
@@ -162,7 +160,6 @@ impl TariNetwork {
     pub fn upper_case(self) -> &'static str {
         match self {
             Self::Dibbler => "DIBBLER",
-            Self::Esme => "ESMERALDA",
             Self::Esmeralda => "ESMERALDA",
             Self::Igor => "IGOR",
             Self::Mainnet => "MAINNET",
@@ -183,7 +180,6 @@ impl TryFrom<&str> for TariNetwork {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
             "dibbler" => Ok(TariNetwork::Dibbler),
-            "esme" => Ok(TariNetwork::Esmeralda),
             "esmeralda" => Ok(TariNetwork::Esmeralda),
             "igor" => Ok(TariNetwork::Igor),
             "mainnet" => Ok(TariNetwork::Mainnet),

--- a/docker_rig/config.toml
+++ b/docker_rig/config.toml
@@ -82,7 +82,7 @@ db_file = "wallet/igor/wallet.dat"
 
 [esmeralda.wallet]
 network = "esmeralda"
-db_file = "wallet/esme/wallet.dat"
+db_file = "wallet/esmeralda/wallet.dat"
 
 [miner]
 base_node_grpc_address = "/dns4/base_node/tcp/18142"

--- a/gui-react/src/containers/BaseNodeContainer/constants.ts
+++ b/gui-react/src/containers/BaseNodeContainer/constants.ts
@@ -1,4 +1,4 @@
-export const networks = ['esme', 'dibbler', 'testnet']
+export const networks = ['esmeralda', 'dibbler', 'testnet']
 
 export const networkOptions = networks.map(network => ({
   label: network,

--- a/gui-react/src/containers/BaseNodeContainer/types.ts
+++ b/gui-react/src/containers/BaseNodeContainer/types.ts
@@ -1,4 +1,4 @@
-export type Network = 'esme' | 'dibbler' | 'testnet'
+export type Network = 'esmeralda' | 'dibbler' | 'testnet'
 
 export interface BaseNodeProps {
   startNode: () => void

--- a/gui-react/src/store/baseNode/index.ts
+++ b/gui-react/src/store/baseNode/index.ts
@@ -5,7 +5,7 @@ import { Network } from '../../containers/BaseNodeContainer/types'
 import { BaseNodeState } from './types'
 
 const initialState: BaseNodeState = {
-  network: 'esme',
+  network: 'esmeralda',
   rootFolder: '',
   identity: undefined,
 }

--- a/gui-react/src/store/containers/thunks.test.ts
+++ b/gui-react/src/store/containers/thunks.test.ts
@@ -92,7 +92,7 @@ describe('containers/thunks', () => {
       const getState = () =>
         ({
           baseNode: {
-            network: 'esme',
+            network: 'esmeralda',
           },
           containers: {
             statsHistory: [],


### PR DESCRIPTION
Description
---
Using the esme shorthand created a regression in the Aurora base node selector QR code. To avoid issues like this in the future remove all shorthand and only use the longform.

Motivation and Context
---
It caused a regression with Aurora, and now that I think of it might have been why windows directories we're being created wrong 🤔

How Has This Been Tested?
---
Manually

Fixes: #137 