### PR TITLE
feat: move window using a backdrop of a modal window

### DIFF
--- a/gui-react/src/components/Modal/index.tsx
+++ b/gui-react/src/components/Modal/index.tsx
@@ -13,6 +13,7 @@ const Modal = ({ open, children, onClose, size, local, style }: ModalProps) => {
   return (
     <ModalContainer local={local}>
       <Backdrop
+        data-tauri-drag-region
         onClick={onClose}
         data-testid='modal-backdrop'
         $opacity={0.5}


### PR DESCRIPTION
Description
---
Allow to move app's window by dragging a backdrop of a modal window.

Motivation and Context
---
A backdrop of a modal window overlaps the title bar and doesn't allow to move window when the modal (settings) is opened.

Fixes #128 

How Has This Been Tested?
---
Manually
