### PR TITLE
fix: add draggable region to splash screen

### DIFF
--- a/gui-react/public/index.html
+++ b/gui-react/public/index.html
@@ -29,7 +29,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="splashscreen">
+    <div data-tauri-drag-region id="splashscreen">
       <video id="vid" width="250" height="250" muted="" loop="" autoplay="" playsinline="" style="opacity: 1;">
         <source src="%PUBLIC_URL%/sphere.mp4" type="video/mp4">
       </video>


### PR DESCRIPTION
Description
---
Made the app draggable when the splash screen is loading

Motivation and Context
---
When the app first loads and the loading animation is playing, you are not able to move the window around on the desktop

How Has This Been Tested?
---
Manually
