### PR TITLE
fix: Mining settings

### DIFF
--- a/gui-react/src/containers/SettingsContainer/MiningSettings/MiningSettings.tsx
+++ b/gui-react/src/containers/SettingsContainer/MiningSettings/MiningSettings.tsx
@@ -103,7 +103,6 @@ const MiningSettings = ({
           name='mining.merged.address'
           control={control}
           rules={{
-            required: true,
             minLength: {
               value: 12,
               message: t.mining.settings.moneroAddressError,

--- a/gui-react/src/containers/SettingsContainer/MiningSettings/MiningSettings.tsx
+++ b/gui-react/src/containers/SettingsContainer/MiningSettings/MiningSettings.tsx
@@ -60,6 +60,44 @@ const MiningSettings = ({
         </Text>
       </SettingsHeader>
 
+      <SettingsSectionHeader noBottomMargin noTopMargin>
+        {t.common.nouns.shaMining}
+      </SettingsSectionHeader>
+
+      <NarrowInlineInput>
+        <Label>{t.mining.settings.threadsLabel}</Label>
+        <Controller
+          name='mining.merged.threads'
+          control={control}
+          rules={{ required: true, minLength: 1 }}
+          render={({ field }) => (
+            <Input
+              testId='mining-merged-threads-input'
+              onChange={value => {
+                // convert string into number
+                const stripped = value.replace(/\D/g, '')
+                let val = !stripped
+                  ? ''
+                  : Math.abs(Math.round(parseInt(stripped)))
+
+                // limit the number of threads to maxThreads
+                if (val > MiningConfig.maxThreads) {
+                  val = MiningConfig.maxThreads
+                }
+                field.onChange(val)
+              }}
+              value={field?.value?.toString() || ''}
+              containerStyle={{ maxWidth: 96 }}
+              withError={false}
+            />
+          )}
+        />
+      </NarrowInlineInput>
+
+      <SettingsSectionHeader noBottomMargin noTopMargin>
+        {t.common.nouns.mergeMining}
+      </SettingsSectionHeader>
+
       <div style={{ width: '70%' }}>
         <Controller
           name='mining.merged.address'
@@ -104,36 +142,6 @@ const MiningSettings = ({
       <SettingsSectionHeader noBottomMargin>
         {t.common.nouns.expert}
       </SettingsSectionHeader>
-
-      <NarrowInlineInput>
-        <Label>{t.mining.settings.threadsLabel}</Label>
-        <Controller
-          name='mining.merged.threads'
-          control={control}
-          rules={{ required: true, minLength: 1 }}
-          render={({ field }) => (
-            <Input
-              testId='mining-merged-threads-input'
-              onChange={value => {
-                // convert string into number
-                const stripped = value.replace(/\D/g, '')
-                let val = !stripped
-                  ? ''
-                  : Math.abs(Math.round(parseInt(stripped)))
-
-                // limit the number of threads to maxThreads
-                if (val > MiningConfig.maxThreads) {
-                  val = MiningConfig.maxThreads
-                }
-                field.onChange(val)
-              }}
-              value={field?.value?.toString() || ''}
-              containerStyle={{ maxWidth: 96 }}
-              withError={false}
-            />
-          )}
-        />
-      </NarrowInlineInput>
 
       {isAuthApplied ? (
         <RowSpacedBetween>

--- a/gui-react/src/locales/common.ts
+++ b/gui-react/src/locales/common.ts
@@ -25,6 +25,8 @@ const translations: { [key: string]: { [key: string]: string } } = {
     tariWallet: 'Tari Wallet',
     moneroWallet: 'Monero Wallet',
     mining: 'Mining',
+    shaMining: 'SHA3 Mining',
+    mergeMining: 'Monero Merge Mining',
     problem: 'Problem',
     settings: 'Settings',
     wallet: 'Wallet',


### PR DESCRIPTION
Description
---
There was a bug on the settings page which wouldn't allow some setting changes to be saved. The dirty tracking was working fine but the Save would not enable. This was because by default there is no value for the monero address but the monero address was marked as a required field. Meaning until one was entered no other changes were considered valid for saving. 

I fixed this by removing the requirement of having the monero address.

Additionally I separated the SHA3 mining cores number from the rest of the monero mining settings.
New layout:

<img width="646" alt="image" src="https://user-images.githubusercontent.com/179134/191717318-1f36aed1-0a71-4384-b830-f11b1d548bbe.png">


Motivation and Context
---
The settings page felt broken as you would make changes but still couldn't save or apply your changes seemingly without reason.

Fixes: #159 
Fixes: #161 

How Has This Been Tested?
---
Manually
