### PR TITLE
feat: set prune horizon as default for base node

### DIFF
--- a/backend/assets/config.toml
+++ b/backend/assets/config.toml
@@ -5,6 +5,8 @@ grpc_address = "/ip4/0.0.0.0/tcp/18142"
 override_from = "esmeralda"
 
 [base_node.storage]
+pruning_horizon = 10_800
+pruning_interval = 50
 track_reorgs = true
 
 [dibbler.base_node]


### PR DESCRIPTION
Description
---
Make the base node a pruned node by default

Motivation and Context
---
Keeping LP a bit smaller

Fixes: #167 

How Has This Been Tested?
---
yolo
