### PR TITLE
chore: docker entry shell form

### DIFF
--- a/docker_rig/tarilabs.Dockerfile
+++ b/docker_rig/tarilabs.Dockerfile
@@ -153,5 +153,5 @@ USER tari
 COPY --from=builder /tari/$APP_EXEC /usr/bin/
 COPY buildtools/docker_rig/start_tari_app.sh /usr/bin/start_tari_app.sh
 
-ENTRYPOINT [ "start_tari_app.sh", "-c", "/var/tari/config/config.toml", "-b", "/var/tari/$APP_NAME" ]
+ENTRYPOINT start_tari_app.sh -c /var/tari/config/config.toml -b /var/tari/$APP_NAME
 # CMD [ "--non-interactive-mode" ]


### PR DESCRIPTION
Description
---
Moves the dockerfile entry to shell form so `$APP_NAME` might actually substitute to the correct path.

Motivation and Context
---
Still getting the `$APP_NAME` directory
![image](https://user-images.githubusercontent.com/179134/191762391-c96094b5-c1c8-4e93-a7cc-e9787479f7e9.png)


How Has This Been Tested?
---
It hasn't
