### PR TITLE
feat: add pull all button to docker settings

### DIFF
--- a/gui-react/src/components/DockerImagesList/index.tsx
+++ b/gui-react/src/components/DockerImagesList/index.tsx
@@ -31,11 +31,13 @@ const DockerImagesList = ({
   header,
   disableIcons,
   style,
+  pullAllBtn,
 }: {
   inverted?: boolean
   header?: boolean
   disableIcons?: boolean
   style?: CSSProperties
+  pullAllBtn?: boolean
 }) => {
   const theme = useTheme()
   const dispatch = useAppDispatch()
@@ -68,40 +70,42 @@ const DockerImagesList = ({
 
   return (
     <DockerList style={style}>
-      <PullAllContainer>
-        {dockerImagesLoading && (
-          <Text
-            style={{ flexBasis: '70%' }}
-            type='smallMedium'
-            color={inverted ? theme.inverted.disabledText : theme.primary}
-          >
-            {t.docker.pullAll.checkingForUpdates}
-          </Text>
-        )}
-        {!dockerImagesLoading && (
-          <>
+      {pullAllBtn && (
+        <PullAllContainer>
+          {dockerImagesLoading && (
             <Text
               style={{ flexBasis: '70%' }}
               type='smallMedium'
               color={inverted ? theme.inverted.disabledText : theme.primary}
             >
-              {needsUpdate.length
-                ? t.docker.pullAll.updatesAvailable
-                : t.docker.pullAll.upToDate}
+              {t.docker.pullAll.checkingForUpdates}
             </Text>
-            {needsUpdate.length > 0 && (
-              <Button
-                variant='primary'
-                onClick={pullAll}
-                disabled={pullBtnDisabled}
-                size='small'
+          )}
+          {!dockerImagesLoading && (
+            <>
+              <Text
+                style={{ flexBasis: '70%' }}
+                type='smallMedium'
+                color={inverted ? theme.inverted.disabledText : theme.primary}
               >
-                {t.docker.pullAll.button}
-              </Button>
-            )}
-          </>
-        )}
-      </PullAllContainer>
+                {needsUpdate.length
+                  ? t.docker.pullAll.updatesAvailable
+                  : t.docker.pullAll.upToDate}
+              </Text>
+              {needsUpdate.length > 0 && (
+                <Button
+                  variant='primary'
+                  onClick={pullAll}
+                  disabled={pullBtnDisabled}
+                  size='small'
+                >
+                  {t.docker.pullAll.button}
+                </Button>
+              )}
+            </>
+          )}
+        </PullAllContainer>
+      )}
       {dockerImagesLoading && <LoadingOverlay inverted={inverted} />}
       {header && (
         <DockerRow key='headers'>

--- a/gui-react/src/components/DockerImagesList/styles.ts
+++ b/gui-react/src/components/DockerImagesList/styles.ts
@@ -4,7 +4,9 @@ export const DockerRow = styled.div<{ $inverted?: boolean }>`
   display: flex;
   align-items: center;
   height: 2em;
-  padding: ${({ theme }) => theme.spacingVertical(1.25)};
+  font-size: 0.88em;
+  padding-top: ${({ theme }) => theme.spacingVertical(1.25)};
+  padding-bottom: ${({ theme }) => theme.spacingVertical(1.25)};
   &:not(:last-of-type) {
     border-bottom: 1px solid
       ${({ theme, $inverted }) =>
@@ -51,4 +53,12 @@ export const TextProgessContainer = styled.span`
   text-overflow: ellipsis;
   max-width: 100%;
   overflow: hidden;
+`
+
+export const PullAllContainer = styled.div`
+  padding-bottom: ${({ theme }) => theme.spacingVertical(1.25)};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid ${({ theme }) => theme.selectBorderColor};
 `

--- a/gui-react/src/containers/SettingsContainer/DockerSettings/DockerSettings.tsx
+++ b/gui-react/src/containers/SettingsContainer/DockerSettings/DockerSettings.tsx
@@ -95,7 +95,6 @@ const DockerSettings = ({
       <DockerImagesList
         style={{
           marginBottom: theme.spacing(),
-          marginLeft: `-${theme.spacingHorizontal(1.2)}`,
         }}
       />
     </>

--- a/gui-react/src/containers/SettingsContainer/DockerSettings/DockerSettings.tsx
+++ b/gui-react/src/containers/SettingsContainer/DockerSettings/DockerSettings.tsx
@@ -93,6 +93,7 @@ const DockerSettings = ({
       </SettingsSectionHeader>
 
       <DockerImagesList
+        pullAllBtn
         style={{
           marginBottom: theme.spacing(),
         }}

--- a/gui-react/src/locales/docker.ts
+++ b/gui-react/src/locales/docker.ts
@@ -13,6 +13,12 @@ export default {
     image: 'Image',
     status: 'Status',
   },
+  pullAll: {
+    button: 'Pull all',
+    checkingForUpdates: 'Checking for updates...',
+    updatesAvailable: 'There are images with updates available',
+    upToDate: 'All images are up to date',
+  },
   tBot: {
     newVersionAvailable: {
       part1: 'There is a newer version of wallet image ready to pull.',


### PR DESCRIPTION
Description
---
Added a pull all button to the docker settings page.
Also fixed a couple of alignment and font size issues on the same page.

Motivation and Context
---
Previously, if there were many new images available, the user would have to click on each one separately to download. This allows for a single click to download all available images.
Issue #146 

How Has This Been Tested?
---
Manually
