### PR TITLE
feat: move reset button to danger zone area

### DIFF
--- a/gui-react/src/containers/SettingsContainer/ResetSettings/ResetSettings.tsx
+++ b/gui-react/src/containers/SettingsContainer/ResetSettings/ResetSettings.tsx
@@ -11,7 +11,6 @@ import { SettingsHeader } from '../styles'
 import { ResetSettingsInputs } from './../types'
 
 const ResetSettings = ({
-  confirmCancel,
   confirmReset,
   onReset,
   resetDiscard,
@@ -54,22 +53,23 @@ const ResetSettings = ({
       </div>
 
       {confirmReset && (
-        <div>
-          <DiscardWarning>
-            <Text type='smallHeavy'>{t.settings.resetChanges}</Text>
-            <Text type='smallMedium'>{t.settings.resetChangesDesc}.</Text>
-          </DiscardWarning>
+        <div
+          style={{
+            display: 'flex',
+            gap: theme.spacingHorizontal(1),
+          }}
+        >
           <Button variant='secondary' onClick={resetDiscard} size='small'>
             {t.common.phrases.keepEditing}
           </Button>
-          <Button onClick={resetSettings} variant='warning' size='small'>
+          <Button onClick={resetSettings} variant='primary' size='small'>
             {t.settings.resetAndExit}
           </Button>
         </div>
       )}
-      {!confirmCancel && !confirmReset && (
+      {!confirmReset && (
         <div>
-          <Button variant='secondary' onClick={onReset}>
+          <Button variant='primary' onClick={onReset} size='small'>
             {t.common.verbs.reset}
           </Button>
         </div>

--- a/gui-react/src/containers/SettingsContainer/ResetSettings/ResetSettings.tsx
+++ b/gui-react/src/containers/SettingsContainer/ResetSettings/ResetSettings.tsx
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Control,
+  UseFormSetValue,
+  FormState,
+} from 'react-hook-form'
+import { useTheme } from 'styled-components'
+import { RowFlex, DiscardWarning } from '../styles'
+import Tag from '../../../components/Tag'
+import Button from '../../../components/Button'
+
+import SettingsSectionHeader from '../../../components/SettingsSectionHeader'
+import Text from '../../../components/Text'
+import t from '../../../locales'
+import { SettingsHeader } from '../styles'
+import { SettingsInputs } from '../types'
+
+import { ResetSettingsInputs } from './../types'
+
+const ResetSettings = ({
+  confirmCancel,
+  confirmReset,
+  onReset,
+  resetDiscard,
+  resetSettings,
+}: ResetSettingsInputs) => {
+  const theme = useTheme()
+
+  function reset() {
+    console.log('confirmCancel ', confirmCancel)
+    console.log('confirmReset ', confirmReset)
+  }
+
+  return (
+    <>
+      <SettingsHeader>
+        <Text type='subheader' as='h2' color={theme.primary}>
+          {t.reset.settings.title}
+        </Text>
+      </SettingsHeader>
+
+      <SettingsSectionHeader noTopMargin noBottomMargin>
+        {t.common.nouns.dangerZone}
+      </SettingsSectionHeader>
+
+      <RowFlex
+        style={{
+          marginTop: theme.spacingVertical(1),
+          marginBottom: theme.spacingVertical(1),
+        }}
+      >
+        <Text type='smallMedium' color={theme.primary}>
+          {t.reset.settings.label}
+        </Text>
+        <Tag variant='small' type='warning'>
+          {t.reset.settings.warning}
+        </Tag>
+      </RowFlex>
+      <div
+        style={{
+          color: theme.secondary,
+          marginBottom: theme.spacingVertical(1.5),
+        }}
+      >
+        <Text type='smallMedium'>{t.reset.settings.description}</Text>
+      </div>
+
+      {confirmReset && (
+        <div>
+          <DiscardWarning>
+            <Text type='smallHeavy'>{t.settings.resetChanges}</Text>
+            <Text type='smallMedium'>{t.settings.resetChangesDesc}.</Text>
+          </DiscardWarning>
+          <Button variant='secondary' onClick={resetDiscard} size='small'>
+            {t.common.phrases.keepEditing}
+          </Button>
+          <Button onClick={resetSettings} variant='warning' size='small'>
+            {t.settings.resetAndExit}
+          </Button>
+        </div>
+      )}
+      {!confirmCancel && !confirmReset && (
+        <div>
+          <Button variant='secondary' onClick={onReset}>
+            {t.common.verbs.reset}
+          </Button>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default ResetSettings

--- a/gui-react/src/containers/SettingsContainer/ResetSettings/ResetSettings.tsx
+++ b/gui-react/src/containers/SettingsContainer/ResetSettings/ResetSettings.tsx
@@ -1,9 +1,3 @@
-import {
-  Controller,
-  Control,
-  UseFormSetValue,
-  FormState,
-} from 'react-hook-form'
 import { useTheme } from 'styled-components'
 import { RowFlex, DiscardWarning } from '../styles'
 import Tag from '../../../components/Tag'
@@ -13,7 +7,6 @@ import SettingsSectionHeader from '../../../components/SettingsSectionHeader'
 import Text from '../../../components/Text'
 import t from '../../../locales'
 import { SettingsHeader } from '../styles'
-import { SettingsInputs } from '../types'
 
 import { ResetSettingsInputs } from './../types'
 
@@ -25,11 +18,6 @@ const ResetSettings = ({
   resetSettings,
 }: ResetSettingsInputs) => {
   const theme = useTheme()
-
-  function reset() {
-    console.log('confirmCancel ', confirmCancel)
-    console.log('confirmReset ', confirmReset)
-  }
 
   return (
     <>

--- a/gui-react/src/containers/SettingsContainer/ResetSettings/index.tsx
+++ b/gui-react/src/containers/SettingsContainer/ResetSettings/index.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { Control, FormState, UseFormSetValue } from 'react-hook-form'
+import { SettingsInputs } from '../types'
+import ResetSettings from './ResetSettings'
+import { actions } from '../../../store/settings'
+import { useAppDispatch } from '../../../store/hooks'
+
+const ResetSettingsContainer = ({
+  formState,
+  control,
+  values,
+  setValue,
+  setOpenMiningAuthForm,
+}: {
+  formState: FormState<SettingsInputs>
+  control: Control<SettingsInputs>
+  values: SettingsInputs
+  setValue: UseFormSetValue<SettingsInputs>
+  setOpenMiningAuthForm: (value: boolean) => void
+}) => {
+  const dispatch = useAppDispatch()
+  const [confirmReset, setConfirmReset] = useState(false)
+
+  const tryToReset = () => {
+    setConfirmReset(true)
+  }
+
+  const resetSettings = () => {
+    setConfirmReset(false)
+    dispatch(actions.resetSettingsAndRelaunch())
+  }
+
+  return (
+    <ResetSettings
+      confirmCancel={false}
+      confirmReset={confirmReset}
+      onReset={tryToReset}
+      resetDiscard={() => setConfirmReset(false)}
+      resetSettings={resetSettings}
+    />
+  )
+}
+
+export default ResetSettingsContainer

--- a/gui-react/src/containers/SettingsContainer/ResetSettings/index.tsx
+++ b/gui-react/src/containers/SettingsContainer/ResetSettings/index.tsx
@@ -1,23 +1,9 @@
 import { useState } from 'react'
-import { Control, FormState, UseFormSetValue } from 'react-hook-form'
-import { SettingsInputs } from '../types'
 import ResetSettings from './ResetSettings'
 import { actions } from '../../../store/settings'
 import { useAppDispatch } from '../../../store/hooks'
 
-const ResetSettingsContainer = ({
-  formState,
-  control,
-  values,
-  setValue,
-  setOpenMiningAuthForm,
-}: {
-  formState: FormState<SettingsInputs>
-  control: Control<SettingsInputs>
-  values: SettingsInputs
-  setValue: UseFormSetValue<SettingsInputs>
-  setOpenMiningAuthForm: (value: boolean) => void
-}) => {
+const ResetSettingsContainer = () => {
   const dispatch = useAppDispatch()
   const [confirmReset, setConfirmReset] = useState(false)
 
@@ -32,7 +18,6 @@ const ResetSettingsContainer = ({
 
   return (
     <ResetSettings
-      confirmCancel={false}
       confirmReset={confirmReset}
       onReset={tryToReset}
       resetDiscard={() => setConfirmReset(false)}

--- a/gui-react/src/containers/SettingsContainer/SecuritySettings/index.tsx
+++ b/gui-react/src/containers/SettingsContainer/SecuritySettings/index.tsx
@@ -71,11 +71,11 @@ const SecuritySettingsContainer = () => {
 
       <div style={{ display: 'inline-flex' }}>
         {alreadyCreated ? (
-          <Button onClick={() => undefined} disabled>
+          <Button onClick={() => undefined} disabled size='small'>
             {t.settings.security.alreadyCreated}
           </Button>
         ) : (
-          <Button onClick={() => setOpenSeedPhraseModal(true)}>
+          <Button onClick={() => setOpenSeedPhraseModal(true)} size='small'>
             {t.settings.security.createRecoveryPhrase}
           </Button>
         )}

--- a/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
+++ b/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
@@ -77,15 +77,7 @@ const renderSettings = (
     case Settings.Security:
       return <SecuritySettings />
     case Settings.Reset:
-      return (
-        <ResetSettings
-          formState={props.formState}
-          control={props.control}
-          values={props.values}
-          setValue={props.setValue}
-          setOpenMiningAuthForm={props.setOpenMiningAuthForm}
-        />
-      )
+      return <ResetSettings />
     default:
       return null
   }
@@ -94,7 +86,6 @@ const renderSettings = (
 const SettingsComponent = ({
   open,
   onClose,
-  onReset,
   activeSettings,
   goToSettings,
   formState,
@@ -104,11 +95,8 @@ const SettingsComponent = ({
   defaultMiningMergedValues,
   onSubmit,
   confirmCancel,
-  confirmReset,
   cancelDiscard,
-  resetDiscard,
   discardChanges,
-  resetSettings,
   openMiningAuthForm,
   setOpenMiningAuthForm,
   openBaseNodeConnect,
@@ -226,25 +214,8 @@ const SettingsComponent = ({
             </Button>
           </Footer>
         )}
-        {confirmReset && (
+        {!confirmCancel && (
           <Footer>
-            <DiscardWarning>
-              <Text type='smallHeavy'>{t.settings.resetChanges}</Text>
-              <Text type='smallMedium'>{t.settings.resetChangesDesc}.</Text>
-            </DiscardWarning>
-            <Button variant='secondary' onClick={resetDiscard} size='small'>
-              {t.common.phrases.keepEditing}
-            </Button>
-            <Button onClick={resetSettings} variant='warning' size='small'>
-              {t.settings.resetAndExit}
-            </Button>
-          </Footer>
-        )}
-        {!confirmCancel && !confirmReset && (
-          <Footer>
-            <Button variant='secondary' onClick={onReset}>
-              {t.common.verbs.reset}
-            </Button>
             <Spacer />
             <Button variant='secondary' onClick={onClose}>
               {t.common.verbs.cancel}

--- a/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
+++ b/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
@@ -28,6 +28,7 @@ import BaseNodeSettings from './BaseNodeSettings'
 import MiningSettings from './MiningSettings'
 import DockerSettings from './DockerSettings'
 import WalletSettings from './WalletSettings'
+import ResetSettings from './ResetSettings'
 import {
   SettingsProps,
   SettingsComponentProps,
@@ -75,6 +76,16 @@ const renderSettings = (
       )
     case Settings.Security:
       return <SecuritySettings />
+    case Settings.Reset:
+      return (
+        <ResetSettings
+          formState={props.formState}
+          control={props.control}
+          values={props.values}
+          setValue={props.setValue}
+          setOpenMiningAuthForm={props.setOpenMiningAuthForm}
+        />
+      )
     default:
       return null
   }

--- a/gui-react/src/containers/SettingsContainer/index.tsx
+++ b/gui-react/src/containers/SettingsContainer/index.tsx
@@ -32,7 +32,6 @@ const SettingsContainer = () => {
   const [openMiningAuthForm, setOpenMiningAuthForm] = useState(false)
   const [openBaseNodeConnect, setOpenBaseNodeConnect] = useState(false)
   const [confirmCancel, setConfirmCancel] = useState(false)
-  const [confirmReset, setConfirmReset] = useState(false)
 
   const defaultValues = useMemo(
     () => ({
@@ -87,10 +86,6 @@ const SettingsContainer = () => {
     setConfirmCancel(true)
   }
 
-  const tryToReset = () => {
-    setConfirmReset(true)
-  }
-
   const changeTheme = (theme: ThemeType) => {
     dispatch(setTheme(theme))
   }
@@ -103,16 +98,10 @@ const SettingsContainer = () => {
     dispatch(actions.close())
   }
 
-  const resetSettings = () => {
-    setConfirmReset(false)
-    dispatch(actions.resetSettingsAndRelaunch())
-  }
-
   return (
     <SettingsComponent
       open={settingsOpen}
       onClose={tryToClose}
-      onReset={tryToReset}
       activeSettings={activeSettings}
       goToSettings={settingsPage => dispatch(actions.goTo(settingsPage))}
       formState={formState}
@@ -122,11 +111,8 @@ const SettingsContainer = () => {
       control={control}
       defaultMiningMergedValues={getValues().mining.merged}
       confirmCancel={confirmCancel}
-      confirmReset={confirmReset}
       cancelDiscard={() => setConfirmCancel(false)}
-      resetDiscard={() => setConfirmReset(false)}
       discardChanges={closeAndDiscard}
-      resetSettings={resetSettings}
       openMiningAuthForm={openMiningAuthForm}
       setOpenMiningAuthForm={setOpenMiningAuthForm}
       openBaseNodeConnect={openBaseNodeConnect}

--- a/gui-react/src/containers/SettingsContainer/styles.ts
+++ b/gui-react/src/containers/SettingsContainer/styles.ts
@@ -130,7 +130,7 @@ export const SwitchBg = styled.div<{ $transparent?: boolean }>`
 
 export const RowFlex = styled.div`
   display: flex;
-  align-tiems: center;
+  align-items: center;
   column-gap: ${({ theme }) => theme.spacingHorizontal(0.5)};
 `
 

--- a/gui-react/src/containers/SettingsContainer/types.ts
+++ b/gui-react/src/containers/SettingsContainer/types.ts
@@ -42,6 +42,14 @@ export interface BaseNodeSettingsInputs {
   rootFolder: string
 }
 
+export interface ResetSettingsInputs {
+  confirmCancel: boolean
+  confirmReset: boolean
+  onReset: () => void
+  resetDiscard: () => void
+  resetSettings: () => void
+}
+
 export type SettingsComponentProps = {
   open?: boolean
   onClose: () => void

--- a/gui-react/src/containers/SettingsContainer/types.ts
+++ b/gui-react/src/containers/SettingsContainer/types.ts
@@ -43,7 +43,6 @@ export interface BaseNodeSettingsInputs {
 }
 
 export interface ResetSettingsInputs {
-  confirmCancel: boolean
   confirmReset: boolean
   onReset: () => void
   resetDiscard: () => void
@@ -53,7 +52,6 @@ export interface ResetSettingsInputs {
 export type SettingsComponentProps = {
   open?: boolean
   onClose: () => void
-  onReset: () => void
   goToSettings: (s: Settings) => void
   activeSettings: Settings
   formState: FormState<SettingsInputs>
@@ -63,11 +61,8 @@ export type SettingsComponentProps = {
   onSubmit: () => void
   control: Control<SettingsInputs>
   confirmCancel: boolean
-  confirmReset: boolean
   cancelDiscard: () => void
-  resetDiscard: () => void
   discardChanges: () => void
-  resetSettings: () => void
   openMiningAuthForm: boolean
   setOpenMiningAuthForm: (value: boolean) => void
   openBaseNodeConnect: boolean

--- a/gui-react/src/locales/common.ts
+++ b/gui-react/src/locales/common.ts
@@ -39,6 +39,8 @@ const translations: { [key: string]: { [key: string]: string } } = {
     error: 'Error',
     today: 'Today',
     results: 'Results',
+    reset: 'Reset',
+    dangerZone: 'Danger Zone',
   },
   weekdayCapitals: {
     sunday: 'S',

--- a/gui-react/src/locales/index.ts
+++ b/gui-react/src/locales/index.ts
@@ -21,6 +21,7 @@ import onboardingI18n from './onboarding'
 import dockerI18n from './docker'
 import passwordPromptI18n from './passwordPrompt'
 import onlineIl8n from './online'
+import resetIl8n from './reset'
 
 const translations = {
   common: commonI18n,
@@ -37,6 +38,7 @@ const translations = {
   docker: dockerI18n,
   passwordPrompt: passwordPromptI18n,
   online: onlineIl8n,
+  reset: resetIl8n,
 }
 
 export default translations

--- a/gui-react/src/locales/reset.ts
+++ b/gui-react/src/locales/reset.ts
@@ -3,7 +3,8 @@ export default {
     title: 'Reset Settings',
     label: 'Reset changes',
     warning: '⚠️ This action cannot be undone',
-    description: 'Clean all settings and start from scratch',
+    description:
+      'Clean all settings and start from scratch (requires restarting)',
     resetButton: 'Reset',
   },
 }

--- a/gui-react/src/locales/reset.ts
+++ b/gui-react/src/locales/reset.ts
@@ -1,0 +1,9 @@
+export default {
+  settings: {
+    title: 'Reset Settings',
+    label: 'Reset changes',
+    warning: '⚠️ This action cannot be undone',
+    description: 'Clean all settings and start from scratch',
+    resetButton: 'Reset',
+  },
+}

--- a/gui-react/src/store/settings/types.ts
+++ b/gui-react/src/store/settings/types.ts
@@ -5,6 +5,7 @@ export enum Settings {
   Docker = 'docker',
   // Logs = 'logs',
   Security = 'security',
+  Reset = 'reset',
 }
 
 export interface InitialSettings {


### PR DESCRIPTION
Description
---
Moved reset functionality to a separate section / danger zone in the settings menu

Motivation and Context
---
The button was too easily accessible, causing some users to reset their settings accidentally
Issue #151 

How Has This Been Tested?
---
Manually
