### PR TITLE
[DNM] feat: Use new `LaunchPadState` 

### DIFF
--- a/gui-react/__tests__/mocks/states/containersStateTemplates.ts
+++ b/gui-react/__tests__/mocks/states/containersStateTemplates.ts
@@ -11,7 +11,7 @@ const noErrors = {
   [Container.Tor]: undefined,
   [Container.BaseNode]: undefined,
   [Container.Wallet]: undefined,
-  [Container.SHA3Miner]: undefined,
+  [Container.Sha3Miner]: undefined,
   [Container.MMProxy]: undefined,
   [Container.XMrig]: undefined,
   [Container.Monerod]: undefined,
@@ -77,7 +77,7 @@ export const tariContainersRunning: ContainersState = {
       Container.Tor,
       Container.BaseNode,
       Container.Wallet,
-      Container.SHA3Miner,
+      Container.Sha3Miner,
     ]),
   },
   stats: {
@@ -85,7 +85,7 @@ export const tariContainersRunning: ContainersState = {
       Container.Tor,
       Container.BaseNode,
       Container.Wallet,
-      Container.SHA3Miner,
+      Container.Sha3Miner,
     ]),
   },
 }

--- a/gui-react/src/App.tsx
+++ b/gui-react/src/App.tsx
@@ -30,12 +30,15 @@ import { useDockerTBotQueue } from './useDockerTBotQueue'
 import { useInternetCheck } from './useInternetCheck'
 import { useWaitingWalletPassConfirm } from './useWaitingWalletPassConfirm'
 
+import { useListenForDelta } from './hooks/useListenForDelta'
+import { connect, getLaunchPadState } from './store/launchpadState'
+
 const AppContainer = styled.div`
   background: ${({ theme }) => theme.background};
   display: flex;
   flex: 1;
   overflow: hidden;
-  border-radius: 10;
+  border-radius: 10px;
 `
 const OnboardedAppContainer = ({
   children,
@@ -77,6 +80,7 @@ const App = () => {
         await dispatch(init()).unwrap()
         setInitialized(true)
         hideSplashscreen()
+        await dispatch(connect()).unwrap()
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error('App exception:', err)
@@ -91,6 +95,13 @@ const App = () => {
   useDockerEvents({ dispatch })
   useDockerImageDownloadListener({ dispatch })
   useInternetCheck({ dispatch })
+  useListenForDelta({ dispatch })
+
+  useEffect(() => {
+    if (initialized) {
+      dispatch(getLaunchPadState())
+    }
+  }, [initialized, dispatch])
 
   return (
     <ThemeProvider theme={themeConfig}>

--- a/gui-react/src/components/DockerImagesList/index.tsx
+++ b/gui-react/src/components/DockerImagesList/index.tsx
@@ -197,7 +197,7 @@ const DockerImagesList = ({
                   onClick={() =>
                     dispatch(
                       actions.pullImage({
-                        dockerImage: dockerImage.containerName,
+                        dockerImage: dockerImage?.containerName,
                       }),
                     )
                   }

--- a/gui-react/src/components/NodeBox/index.tsx
+++ b/gui-react/src/components/NodeBox/index.tsx
@@ -66,7 +66,7 @@ const NodeBox = ({
           >
             <SvgQuestion
               onClick={onHelpPromptClick}
-              useGradient={helpSvgGradient}
+              data-usegradient={helpSvgGradient}
               color={tag?.type === 'light' ? theme.accent : 'inherit'}
             />
           </SvgContainer>

--- a/gui-react/src/components/Switch/index.tsx
+++ b/gui-react/src/components/Switch/index.tsx
@@ -19,7 +19,7 @@ import { SwitchProps } from './types'
  * @param {string | ReactNode} [rightLabel] - the text or ReactNode element on the right side of the switch.
  * @param {(val: boolean) => void} onClick - when the switch is clicked. Returns the new value.
  * @param {boolean} [inverted] - use inverted styles
- * @param {boolean} [disable] - disable switch interaction
+ * @param {boolean} [$disable] - disable switch interaction
  * @param {string} [testId] - the test ID (react-testing/jest)
  *
  * @example
@@ -90,7 +90,7 @@ const Switch = ({
   return (
     <SwitchContainer
       onClick={() => onClick && !disable && onClick(!value)}
-      disable={disable}
+      $disable={disable}
       data-testid={testId || 'switch-input-cmp'}
     >
       {leftLabelEl ? (
@@ -104,8 +104,8 @@ const Switch = ({
         </LabelText>
       ) : null}
 
-      <SwitchController style={{ ...controllerAnim }} disable={disable}>
-        <SwitchCircle style={{ ...circleAnim }} disable={disable} />
+      <SwitchController style={{ ...controllerAnim }} $disable={disable}>
+        <SwitchCircle style={{ ...circleAnim }} $disable={disable} />
       </SwitchController>
 
       {rightLabelEl ? (

--- a/gui-react/src/components/Switch/styles.ts
+++ b/gui-react/src/components/Switch/styles.ts
@@ -2,29 +2,29 @@ import { animated } from 'react-spring'
 import styled from 'styled-components'
 import colors from '../../styles/styles/colors'
 
-export const SwitchContainer = styled.label<{ disable?: boolean }>`
+export const SwitchContainer = styled.label<{ $disable?: boolean }>`
   display: flex;
   align-items: center;
-  cursor: ${({ disable }) => (disable ? '' : 'pointer')};
+  cursor: ${({ $disable }) => ($disable ? '' : 'pointer')};
 `
 
-export const SwitchController = styled(animated.div)<{ disable?: boolean }>`
+export const SwitchController = styled(animated.div)<{ $disable?: boolean }>`
   height: 14px;
   width: 24px;
   border: 1.5px solid
-    ${({ theme, disable }) =>
-      disable ? theme.disabledText : theme.switchBorder};
+    ${({ theme, $disable }) =>
+      $disable ? theme.disabledText : theme.switchBorder};
   border-radius: 6px;
   position: relative;
   box-sizing: border-box;
   box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.08);
-  cursor: ${({ disable }) => (disable ? '' : 'pointer')};
+  cursor: ${({ $disable }) => ($disable ? '' : 'pointer')};
   -webkit-box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
   -moz-box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
   box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
 `
 
-export const SwitchCircle = styled(animated.div)<{ disable?: boolean }>`
+export const SwitchCircle = styled(animated.div)<{ $disable?: boolean }>`
   position: absolute;
   width: 14px;
   height: 14px;
@@ -35,8 +35,8 @@ export const SwitchCircle = styled(animated.div)<{ disable?: boolean }>`
   box-sizing: border-box;
   background: ${({ theme }) => theme.accent};
   border: 1.5px solid
-    ${({ theme, disable }) =>
-      disable ? theme.disabledText : theme.switchBorder};
+    ${({ theme, $disable }) =>
+      $disable ? theme.disabledText : theme.switchBorder};
   -webkit-box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
   -moz-box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
   box-shadow: 0px 0px 2px -1px ${colors.dark.primary};

--- a/gui-react/src/containers/Dashboard/ExpertView/Containers/Containers.tsx
+++ b/gui-react/src/containers/Dashboard/ExpertView/Containers/Containers.tsx
@@ -29,7 +29,7 @@ import { ContainersTable, TdRight } from './styles'
  * @prop {boolean} running - indicates if container is running
  * @prop {boolean} pending - indicates if container "running" state is about to change
  */
-const Containers = ({ containers, stop, start }: ContainersProps) => {
+const Containers = ({ containers, updateSession }: ContainersProps) => {
   const theme = useTheme()
   const [error, setError] = useState('')
 
@@ -37,16 +37,15 @@ const Containers = ({ containers, stop, start }: ContainersProps) => {
     <>
       <ContainersTable>
         <tbody>
-          {containers.map(container => (
-            <tr key={container.imageName}>
+          {containers?.map(container => (
+            <tr key={container.id}>
               <td>
-                <Text color={theme.inverted.primary}>
-                  {container.displayName}
-                </Text>
+                <Text color={theme.inverted.primary}>{container.id}</Text>
               </td>
               <TdRight>
                 <Text color={theme.secondary} as='span'>
-                  {container.cpu.toFixed(2)}%
+                  CPU val
+                  {/*{container.cpu.toFixed(2)}%*/}
                 </Text>{' '}
                 <Text color={theme.secondary} as='span' type='smallMedium'>
                   {t.common.nouns.cpu}
@@ -54,7 +53,8 @@ const Containers = ({ containers, stop, start }: ContainersProps) => {
               </TdRight>
               <TdRight>
                 <Text color={theme.secondary} as='span'>
-                  {container.memory.toFixed(2)} MB
+                  Mem val
+                  {/*{container.memory.toFixed(2)} MB*/}
                 </Text>{' '}
                 <Text color={theme.secondary} as='span' type='smallMedium'>
                   {t.common.nouns.memory}
@@ -96,7 +96,7 @@ const Containers = ({ containers, stop, start }: ContainersProps) => {
                       paddingLeft: 0,
                       color: theme.inverted.accentSecondary,
                     }}
-                    onClick={() => start(container.container)}
+                    onClick={() => updateSession(container.container)}
                   >
                     <Text type='smallMedium'>{t.common.verbs.start}</Text>
                   </Button>
@@ -118,7 +118,7 @@ const Containers = ({ containers, stop, start }: ContainersProps) => {
                       paddingLeft: 0,
                       color: theme.placeholderText,
                     }}
-                    onClick={() => stop(container.id)}
+                    onClick={() => updateSession(container.container, true)}
                   >
                     <Text type='smallMedium'>{t.common.verbs.stop}</Text>
                   </Button>

--- a/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
+++ b/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
@@ -1,47 +1,47 @@
-import { useState, useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
-import { useAppSelector, useAppDispatch } from '../../../../store/hooks'
-import { selectContainersStatusesWithStats } from '../../../../store/containers/selectors'
-import { Container, ContainerId } from '../../../../store/containers/types'
-import { actions } from '../../../../store/containers'
+import { useAppDispatch, useAppSelector } from '../../../../store/hooks'
+import { Container } from '../../../../store/containers/types'
 import Alert from '../../../../components/Alert'
 
 import Containers from './Containers'
+import { selectContainerStates } from '../../../../store/launchpadState/selectors'
+import { changeSession } from '../../../../store/launchpadState'
+import {
+  Containers as ContainerNameKey,
+  TaskStatus,
+} from '../../../../store/launchpadState/types'
 
 const ContainersContainer = () => {
   const [error, setError] = useState('')
 
   const dispatch = useAppDispatch()
-  const containerStatuses = useAppSelector(selectContainersStatusesWithStats)
-  const containers = useMemo(
+  const containerStates = useAppSelector(selectContainerStates)
+
+  const containers1 = useMemo(
     () =>
-      containerStatuses.map(
-        ({ container, imageName, displayName, status }) => ({
-          id: status.id,
-          container: container as Container,
-          imageName,
-          displayName,
-          error: status.error,
-          cpu: status.stats.cpu,
-          memory: status.stats.memory,
-          pending: status.pending,
-          running: status.running,
-        }),
-      ),
-    [containerStatuses],
+      containerStates.map(({ id, task_state }) => ({
+        id: id,
+        container:
+          Container[
+            id == 'Base Node'
+              ? ('BaseNode' as keyof typeof Container)
+              : (ContainerNameKey[
+                  id as keyof typeof ContainerNameKey
+                ] as keyof typeof Container)
+          ],
+        pending: task_state?.status === TaskStatus.Pending,
+        running: task_state?.status === TaskStatus.Active,
+      })),
+    [containerStates],
   )
 
-  const start = async (container: Container) => {
+  const updateSession = async (container: Container, stop?: boolean) => {
     try {
-      await dispatch(actions.start({ container: container })).unwrap()
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      setError(e.toString())
-    }
-  }
-  const stop = async (containerId: ContainerId) => {
-    try {
-      await dispatch(actions.stop(containerId)).unwrap()
+      const containerField = `${container}_active`
+      await dispatch(
+        changeSession({ sessionItem: { [containerField]: !stop } }),
+      ).unwrap()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       setError(e.toString())
@@ -50,7 +50,7 @@ const ContainersContainer = () => {
 
   return (
     <>
-      <Containers containers={containers} stop={stop} start={start} />
+      <Containers containers={containers1} updateSession={updateSession} />
       <Alert
         title='Error'
         open={Boolean(error)}

--- a/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
+++ b/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
@@ -18,7 +18,7 @@ const ContainersContainer = () => {
   const dispatch = useAppDispatch()
   const containerStates = useAppSelector(selectContainerStates)
 
-  const containers1 = useMemo(
+  const containers = useMemo(
     () =>
       containerStates.map(({ id, task_state }) => ({
         id: id,
@@ -32,6 +32,8 @@ const ContainersContainer = () => {
           ],
         pending: task_state?.status === TaskStatus.Pending,
         running: task_state?.status === TaskStatus.Active,
+        progress:
+          task_state?.status === TaskStatus.Progress ? task_state?.status : {},
       })),
     [containerStates],
   )
@@ -50,7 +52,7 @@ const ContainersContainer = () => {
 
   return (
     <>
-      <Containers containers={containers1} updateSession={updateSession} />
+      <Containers containers={containers} updateSession={updateSession} />
       <Alert
         title='Error'
         open={Boolean(error)}

--- a/gui-react/src/containers/Dashboard/ExpertView/Containers/types.ts
+++ b/gui-react/src/containers/Dashboard/ExpertView/Containers/types.ts
@@ -1,19 +1,18 @@
 import { Container, ContainerId } from '../../../../store/containers/types'
-import { DockerImage } from '../../../../types/general'
 
 type ContainerDto = {
-  id: ContainerId
+  id: ContainerId | undefined
   container: Container
-  cpu: number
+  // cpu: number
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error?: any
-  memory: number
+  // memory: number
   pending: boolean
   running: boolean
-} & Pick<DockerImage, 'imageName' | 'displayName'>
+}
+// & Pick<DockerImage, 'imageName' | 'displayName'>
 
 export type ContainersProps = {
   containers: ContainerDto[]
-  start: (container: Container) => void
-  stop: (container: ContainerId) => void
+  updateSession: (container: Container, stop?: boolean) => void
 }

--- a/gui-react/src/containers/MiningContainer/MiningContainer.integration.test.tsx
+++ b/gui-react/src/containers/MiningContainer/MiningContainer.integration.test.tsx
@@ -50,7 +50,7 @@ describe('MiningContainer with Redux', () => {
       Container.Tor,
       Container.BaseNode,
       Container.Wallet,
-      Container.SHA3Miner,
+      Container.Sha3Miner,
     ]
 
     const store = configureStore({

--- a/gui-react/src/containers/Onboarding/index.tsx
+++ b/gui-react/src/containers/Onboarding/index.tsx
@@ -64,7 +64,7 @@ const OnboardingContainer = () => {
               <DownloadImagesMessage
                 key='dim'
                 onError={onDockerImageDownloadError}
-                onSuccess={onImagesDowloadSuccess}
+                onSuccess={onImagesDownloadSuccess}
               />
             ),
             barFill: 0.625,
@@ -87,7 +87,7 @@ const OnboardingContainer = () => {
     setMessages(newMsgs)
   }
 
-  const onImagesDowloadSuccess = () => {
+  const onImagesDownloadSuccess = () => {
     pushMessages([
       {
         content: <BlockchainSyncStep pushMessages={pushMessages} />,
@@ -106,7 +106,7 @@ const OnboardingContainer = () => {
             <DownloadImagesMessage
               key='dim'
               onError={onDockerImageDownloadError}
-              onSuccess={onImagesDowloadSuccess}
+              onSuccess={onImagesDownloadSuccess}
             />
           ),
           barFill: 0.625,
@@ -126,7 +126,7 @@ const OnboardingContainer = () => {
             key={`dim-${messages.length}`}
             errorType={type}
             onError={onDockerImageDownloadError}
-            onSuccess={onImagesDowloadSuccess}
+            onSuccess={onImagesDownloadSuccess}
           />
         ),
         barFill: 0.625,
@@ -152,7 +152,7 @@ const OnboardingContainer = () => {
             <DownloadImagesMessage
               key={`dim-${messages.length}`}
               onError={onDockerImageDownloadError}
-              onSuccess={onImagesDowloadSuccess}
+              onSuccess={onImagesDownloadSuccess}
             />
           ),
           barFill: 0.625,

--- a/gui-react/src/hooks/useListenForDelta.ts
+++ b/gui-react/src/hooks/useListenForDelta.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import {
+  setLaunchpadDelta,
+  updateStateFromDelta,
+} from '../store/launchpadState'
+import { LaunchPad, LaunchpadDelta } from '../store/launchpadState/types'
+import { listen } from '@tauri-apps/api/event'
+import { AppDispatch } from '../store'
+
+export const useListenForDelta = ({ dispatch }: { dispatch: AppDispatch }) => {
+  const [delta, setDelta] = useState<LaunchpadDelta>()
+  useEffect(() => {
+    const unlisten = listen(
+      'tari://reactions',
+      (event: { payload: LaunchPad }) => {
+        if (event.payload) {
+          const { Delta } = event.payload
+          setDelta(Delta)
+          dispatch(setLaunchpadDelta(Delta))
+          dispatch(updateStateFromDelta(Delta))
+        }
+      },
+    )
+    return () => {
+      unlisten.then(d => d())
+    }
+  }, [])
+  return { delta }
+}

--- a/gui-react/src/hooks/usePreviousLaunchPadDelta.ts
+++ b/gui-react/src/hooks/usePreviousLaunchPadDelta.ts
@@ -1,0 +1,10 @@
+import { useEffect, useRef } from 'react'
+
+function usePrevious<T>(value: T) {
+  const ref = useRef<T>()
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+  return ref.current
+}
+export default usePrevious

--- a/gui-react/src/locales/common.ts
+++ b/gui-react/src/locales/common.ts
@@ -94,7 +94,7 @@ const translations: { [key: string]: { [key: string]: string } } = {
     [Container.Tor]: 'Tor',
     [Container.BaseNode]: 'Base Node',
     [Container.Wallet]: 'Wallet',
-    [Container.SHA3Miner]: 'SHA3 miner',
+    [Container.Sha3Miner]: 'SHA3 miner',
     [Container.MMProxy]: 'Merge miner proxy',
     [Container.XMrig]: 'xmrig',
     [Container.Monerod]: 'monerod',

--- a/gui-react/src/store/containers/index.ts
+++ b/gui-react/src/store/containers/index.ts
@@ -30,7 +30,7 @@ export const initialState: ContainersState = {
     [Container.Tor]: undefined,
     [Container.BaseNode]: undefined,
     [Container.Wallet]: undefined,
-    [Container.SHA3Miner]: undefined,
+    [Container.Sha3Miner]: undefined,
     [Container.MMProxy]: undefined,
     [Container.XMrig]: undefined,
     [Container.Monerod]: undefined,

--- a/gui-react/src/store/containers/types.ts
+++ b/gui-react/src/store/containers/types.ts
@@ -11,13 +11,16 @@ export enum Container {
   Tor = 'tor',
   BaseNode = 'base_node',
   Wallet = 'wallet',
-  SHA3Miner = 'sha3_miner',
+  Sha3Miner = 'sha3_miner',
   MMProxy = 'mm_proxy',
   XMrig = 'xmrig',
   Monerod = 'monerod',
   Loki = 'loki',
   Promtail = 'promtail',
   Grafana = 'grafana',
+  LocalNet = 'localnet',
+  SharedVolume = 'shared_volume',
+  SharedGrafanaVolume = 'shared_grafana_volume',
 }
 
 export enum SystemEventAction {

--- a/gui-react/src/store/index.ts
+++ b/gui-react/src/store/index.ts
@@ -13,6 +13,7 @@ import tbotReducer from './tbot'
 import dockerImagesReducer from './dockerImages'
 import credentialsReducer from './credentials'
 import temporaryReducer from './temporary'
+import launchpadStateReducer from './launchpadState'
 
 // exported for tests
 export const rootReducer = {
@@ -26,6 +27,7 @@ export const rootReducer = {
   dockerImages: dockerImagesReducer,
   credentials: credentialsReducer,
   temporary: temporaryReducer,
+  launchpadState: launchpadStateReducer,
 }
 const reducer = combineReducers(rootReducer)
 

--- a/gui-react/src/store/launchpadState/index.ts
+++ b/gui-react/src/store/launchpadState/index.ts
@@ -1,0 +1,111 @@
+import {
+  Containers,
+  ContainerTaskState,
+  LaunchPad,
+  LaunchpadDelta,
+  LaunchpadState,
+  TaskDelta,
+} from './types'
+import { createAction, createSlice } from '@reduxjs/toolkit'
+
+const initialContainers = Object.assign({}, ...Object.values(Containers))
+export const launchpadStateInitialState: LaunchPad = {
+  State: {
+    config: {
+      session: {},
+      settings: {},
+    },
+    containers: initialContainers,
+    wallet: { active: false, transactions: [] },
+  },
+  Delta: {},
+  taskDeltas: [],
+  launchpadState: {
+    config: { session: {} },
+    containers: [],
+    wallet: { active: false, transactions: [] },
+  },
+}
+
+export const setLaunchpadDelta =
+  createAction<LaunchpadDelta>('setLaunchpadDelta')
+
+export const updateStateFromDelta = createAction<LaunchpadDelta>(
+  'updateStateFromDelta',
+)
+
+const launchpadStateSlice = createSlice({
+  name: 'launchpadState',
+  initialState: launchpadStateInitialState,
+  reducers: {
+    setLaunchpadState(state, { payload }: { payload: LaunchpadState }) {
+      const containers = payload?.containers
+      const containerStates: ContainerTaskState[] = Object.values(
+        Containers,
+      ).map(c => ({
+        id: c,
+        task_state: containers ? containers[c] : undefined,
+      }))
+
+      state.launchpadState = { ...payload, containers: containerStates }
+      state.State = payload
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(setLaunchpadDelta, (state, action) => {
+      const deltaArray: TaskDelta[] = []
+      const newDelta = action.payload?.TaskDelta
+
+      if (deltaArray && newDelta) {
+        const existingTaskId = state.taskDeltas.find(d => d.id === newDelta.id)
+
+        if (existingTaskId && existingTaskId !== -1) {
+          state.taskDeltas[deltaArray.indexOf(existingTaskId)] = newDelta
+        } else {
+          deltaArray.push(newDelta)
+        }
+      }
+
+      state.taskDeltas = state.taskDeltas
+        ? [...state.taskDeltas, ...deltaArray]
+        : deltaArray
+    })
+    builder.addCase(updateStateFromDelta, (state, action) => {
+      if (action.payload?.UpdateConfig) {
+        state.launchpadState.config = {
+          ...state.launchpadState.config,
+          ...action.payload.UpdateConfig,
+        }
+      }
+      if (action.payload?.WalletDelta) {
+        state.launchpadState.wallet = action.payload.WalletDelta
+      }
+      if (
+        action.payload?.TaskDelta &&
+        action.payload.TaskDelta.id &&
+        action.payload.TaskDelta?.delta?.UpdateStatus
+      ) {
+        const containers = state.launchpadState.containers
+        const c = containers.findIndex(
+          c => c.id === action.payload.TaskDelta?.id,
+        )
+
+        containers[c] = {
+          id: action.payload.TaskDelta.id,
+          task_state: {
+            status: action.payload.TaskDelta.delta.UpdateStatus,
+            permanent:
+              state.State.containers[action.payload.TaskDelta.id]?.permanent ||
+              false,
+          },
+        }
+        state.launchpadState.containers = containers
+      }
+    })
+  },
+})
+
+export const { setLaunchpadState } = launchpadStateSlice.actions
+export { connect, changeSession, getLaunchPadState } from './thunks'
+const reducer = launchpadStateSlice.reducer
+export default reducer

--- a/gui-react/src/store/launchpadState/selectors.ts
+++ b/gui-react/src/store/launchpadState/selectors.ts
@@ -1,0 +1,5 @@
+import { RootState } from '../index'
+
+export const selectContainerStates = (rs: RootState) => {
+  return rs?.launchpadState?.launchpadState?.containers
+}

--- a/gui-react/src/store/launchpadState/thunks.ts
+++ b/gui-react/src/store/launchpadState/thunks.ts
@@ -1,0 +1,61 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { emit, listen } from '@tauri-apps/api/event'
+import { LaunchPad, LaunchpadSession } from './types'
+import { setLaunchpadState } from './index'
+import { RootState } from '../index'
+
+export const getLaunchPadState = createAsyncThunk(
+  'app/getLaunchPadState',
+  async (_, thunkApi) => {
+    try {
+      const unlisten = await listen(
+        'tari://reactions',
+        (event: { payload: LaunchPad }) => {
+          if (event.payload.State) {
+            thunkApi.dispatch(setLaunchpadState(event.payload.State))
+          }
+        },
+      )
+
+      return { unlisten }
+    } catch (error) {
+      return thunkApi.rejectWithValue(error)
+    }
+  },
+)
+
+export const changeSession = createAsyncThunk<
+  void,
+  { sessionItem?: Partial<LaunchpadSession> },
+  { state: RootState }
+>('app/changeSession', async ({ sessionItem }, thunkApi) => {
+  try {
+    const rootState = thunkApi.getState()
+
+    const currentSession =
+      rootState.launchpadState.launchpadState?.config?.session
+
+    const sessionUpdate: Partial<LaunchpadSession> = {
+      ...currentSession,
+      ...sessionItem,
+    }
+
+    //TODO ask about shared_grafana_volume_active
+
+    await emit('tari://actions', {
+      Action: {
+        ChangeSession: sessionUpdate,
+      },
+    })
+  } catch (error) {
+    return thunkApi.rejectWithValue(error)
+  }
+})
+
+export const connect = createAsyncThunk('app/connect', async (_, thunkApi) => {
+  try {
+    await emit('tari://actions', { Action: 'Connect' })
+  } catch (error) {
+    return thunkApi.rejectWithValue(error)
+  }
+})

--- a/gui-react/src/store/launchpadState/types.ts
+++ b/gui-react/src/store/launchpadState/types.ts
@@ -20,6 +20,10 @@ export enum TaskStatus {
   Progress = 'Progress',
   Active = 'Active',
 }
+export type TaskProgress = {
+  pct: number
+  stage: string
+}
 
 export type TaskId = string
 
@@ -88,9 +92,10 @@ interface MmProxyConfig {
   monero_password: string
   monero_use_auth: boolean
 }
+export type Task = TaskStatus | { [TaskStatus.Progress]: TaskProgress }
 
 export interface Delta {
-  UpdateStatus: TaskStatus
+  UpdateStatus: Task
   LogRecord?: string
 }
 export interface TaskDelta {
@@ -99,7 +104,7 @@ export interface TaskDelta {
 }
 
 export interface TaskState {
-  status: TaskStatus
+  status: Task
   tail?: Array<string>
   permanent: boolean
 }

--- a/gui-react/src/store/launchpadState/types.ts
+++ b/gui-react/src/store/launchpadState/types.ts
@@ -1,0 +1,144 @@
+//todo move this file
+
+import { WalletBalance } from '../wallet/walletService'
+
+export interface LaunchpadState {
+  config: LaunchpadConfig
+  containers: ContainerState
+  wallet: WalletState
+}
+
+export interface FeState {
+  config: LaunchpadConfig
+  containers: ContainerTaskState[]
+  wallet: WalletState
+}
+
+export enum TaskStatus {
+  Inactive = 'Inactive',
+  Pending = 'Pending',
+  Progress = 'Progress',
+  Active = 'Active',
+}
+
+export type TaskId = string
+
+export enum Containers {
+  Wallet = 'Wallet',
+  Sha3Miner = 'Sha3Miner',
+  Tor = 'Tor',
+  LocalNet = 'LocalNet',
+  SharedVolume = 'SharedVolume',
+  SharedGrafanaVolume = 'SharedGrafanaVolume',
+  Grafana = 'Grafana',
+  BaseNode = 'Base Node',
+  Promtail = 'Promtail',
+  Loki = 'Loki',
+}
+
+interface WalletState {
+  active: boolean
+  balance?: WalletBalance
+  transactions: Array<WalletTransaction>
+}
+
+interface WalletTransaction {
+  event: string
+  tx_id: string
+  source_pk: Array<number>
+  dest_pk: Array<number>
+  status: string
+  direction: string
+  amount: number
+  message: string
+  is_coinbase: boolean
+}
+
+interface LaunchpadConfig {
+  session: Partial<LaunchpadSession>
+  settings?: Partial<Omit<LaunchPadSettings, 'session'>>
+}
+
+interface LaunchPadSettings {
+  session: Partial<LaunchpadSession>
+  data_directory: string
+  tari_network: TariNetwork
+  tor_control_password: string
+  base_node?: Record<string, string>
+  wallet?: { password: string }
+  sha3_miner?: { num_mining_threads: number }
+  mm_proxy?: MmProxyConfig
+  xmrig?: { monero_mining_address: string }
+  registry?: string
+  tag?: string
+  with_monitoring: boolean
+  with_tor: boolean
+}
+
+export enum TariNetwork {
+  Dibbler = 'Dibbler',
+  Esmeralda = 'Esmeralda',
+  Igor = 'Igor',
+  Mainnet = 'Mainnet',
+}
+
+interface MmProxyConfig {
+  monerod_url: string
+  monero_username: string
+  monero_password: string
+  monero_use_auth: boolean
+}
+
+export interface Delta {
+  UpdateStatus: TaskStatus
+  LogRecord?: string
+}
+export interface TaskDelta {
+  id?: Containers
+  delta?: Delta
+}
+
+export interface TaskState {
+  status: TaskStatus
+  tail?: Array<string>
+  permanent: boolean
+}
+
+export type ContainerState = {
+  [Key in Containers as string]?: TaskState | undefined
+}
+export interface ContainerTaskState {
+  id: Containers
+  task_state?: TaskState
+}
+
+export interface LaunchpadDelta {
+  UpdateConfig?: LaunchpadConfig
+  TaskDelta?: TaskDelta
+  WalletDelta?: WalletState
+}
+
+export interface LaunchpadSession {
+  all_active: boolean
+  base_layer_active: boolean
+  merge_layer_active: boolean
+  monitoring_layer_active: boolean
+  tor_active: boolean
+  base_node_active: boolean
+  wallet_active: boolean
+  miner_active: boolean
+  grafana_active: boolean
+  loki_active: boolean
+  promtail_active: boolean
+  //TODO: to ask about this for ChangeSession
+  // shared_grafana_volume_active: boolean
+  // local_net_active: boolean
+  // shared_volume_active: boolean
+}
+
+export interface LaunchPad {
+  State: LaunchpadState
+  Delta: LaunchpadDelta
+  taskDeltas: TaskDelta[]
+  launchpadState: FeState
+}

--- a/gui-react/src/store/mining/selectors.ts
+++ b/gui-react/src/store/mining/selectors.ts
@@ -21,7 +21,7 @@ export const selectTariContainers = createSelector(
   selectContainerStatusWithStats(Container.Tor),
   selectContainerStatusWithStats(Container.BaseNode),
   selectContainerStatusWithStats(Container.Wallet),
-  selectContainerStatusWithStats(Container.SHA3Miner),
+  selectContainerStatusWithStats(Container.Sha3Miner),
   (tor, baseNode, wallet, sha3) => {
     const containers = [tor, baseNode, wallet, sha3]
     const errors = containers

--- a/gui-react/src/store/mining/thunks.ts
+++ b/gui-react/src/store/mining/thunks.ts
@@ -62,7 +62,7 @@ export const startMiningNode = createAsyncThunk<
     if (node === 'tari') {
       await thunkApi
         .dispatch(
-          containersActions.startRecipe({ containerName: Container.SHA3Miner }),
+          containersActions.startRecipe({ containerName: Container.Sha3Miner }),
         )
         .unwrap()
     }
@@ -115,7 +115,7 @@ export const stopMiningNode = createAsyncThunk<
       case 'tari':
         promises.push(
           thunkApi
-            .dispatch(containersActions.stopRecipe(Container.SHA3Miner))
+            .dispatch(containersActions.stopRecipe(Container.Sha3Miner))
             .unwrap(),
         )
         break

--- a/gui-react/src/styles/Icons/Question.tsx
+++ b/gui-react/src/styles/Icons/Question.tsx
@@ -3,7 +3,7 @@ import { SVGProps } from 'react'
 
 const SvgQuestion = (
   props: SVGProps<SVGSVGElement> & {
-    useGradient?: boolean
+    usegradient?: boolean
     testid?: 'help-icon-cmp'
   },
 ) => (
@@ -19,7 +19,7 @@ const SvgQuestion = (
     <path
       d='M8.95 20.647a7.511 7.511 0 0 1-5.597-5.597 13.354 13.354 0 0 1 0-6.1A7.511 7.511 0 0 1 8.95 3.353c2.006-.47 4.094-.47 6.1 0a7.511 7.511 0 0 1 5.597 5.597c.47 2.006.47 4.094 0 6.1a7.511 7.511 0 0 1-5.597 5.597c-2.006.47-4.094.47-6.1 0Z'
       stroke={
-        props.useGradient ? 'url(#paint0_linear_2104_6752)' : 'currentColor'
+        props.usegradient ? 'url(#paint0_linear_2104_6752)' : 'currentColor'
       }
       strokeWidth={1.5}
     />
@@ -28,13 +28,13 @@ const SvgQuestion = (
       cy={15.5}
       r={1}
       fill={
-        props.useGradient ? 'url(#paint1_linear_2104_6752)' : 'currentColor'
+        props.usegradient ? 'url(#paint1_linear_2104_6752)' : 'currentColor'
       }
     />
     <path
       d='M10 10v-.5a2 2 0 0 1 2-2v0a2 2 0 0 1 2 2v.121c0 .563-.223 1.102-.621 1.5L12 12.5'
       stroke={
-        props.useGradient ? 'url(#paint2_linear_2104_6752)' : 'currentColor'
+        props.usegradient ? 'url(#paint2_linear_2104_6752)' : 'currentColor'
       }
       strokeWidth={1.5}
       strokeLinecap='round'

--- a/libs/protocol/src/session.rs
+++ b/libs/protocol/src/session.rs
@@ -21,6 +21,10 @@ pub struct LaunchpadSession {
     pub grafana_active: bool,
     pub loki_active: bool,
     pub promtail_active: bool,
+
+    // pub shared_grafana_volume_active: bool,
+    // pub local_net_active: bool,
+    // pub shared_volume_active: bool,
 }
 
 impl LaunchpadSession {


### PR DESCRIPTION
Description
---
This PR introduces changes to cater for the new `LaunchPadState` structure - currently only being used in the Dashboard ExpertView.

### Changes
- Added a hook to simply listen for deltas
- Added store for launchpadState, including:
  - new types  
  - action to set the `State` from `LaunchPadState` once off
  - action to send action (using `emit('tari://actions', { Action: { ChangeSession: sessionUpdate } })`)
  - push any `Deltas` into a redux state array that can be used where needed (this should be used in the selectors, but the types are all very different - started implementation in `shanimal_implement/lps`, but unsure about where to find container stats in the new structure)
- Small typo fix & addressed some console warnings

### Outstanding (before i would consider this merge-able)
- [ ] **NB** - Container Stats data - Expert view is not great without all that information 
  - started these changes in `shanimal_implement/lps`, but the BE needs to be updated
- [ ] Implementing the changes in other sections.

Motivation and Context
---

This is the start of trying to have the FE use the new structure for `LaunchPadState` - more info in [the readme](https://github.com/tari-project/tari-launchpad/blob/a41e76f5e7208734b5ff4af2bc0fb1213a85ccf3/libs/README.md)


How Has This Been Tested?
---
Manually, locally. Mostly with a lot of `console.log`s :) but you can now use the star/stop buttons in expert view
