### PR TITLE
fix: improve task delta format

### DIFF
--- a/libs/protocol/src/launchpad.rs
+++ b/libs/protocol/src/launchpad.rs
@@ -49,8 +49,8 @@ pub enum LaunchpadAction {
 pub enum LaunchpadDelta {
     UpdateConfig(LaunchpadSettings),
     UpdateSession(LaunchpadSession),
-    TaskAdded(TaskId, TaskState),
-    TaskDelta(TaskId, TaskDelta),
+    TaskAdded { id: TaskId, state: TaskState },
+    TaskDelta { id: TaskId, delta: TaskDelta },
     WalletDelta(WalletDelta),
 }
 
@@ -88,11 +88,11 @@ impl LaunchpadState {
             UpdateSession(session) => {
                 self.config.session = session;
             },
-            TaskAdded(task_id, state) => {
-                self.containers.insert(task_id, state);
+            TaskAdded { id, state } => {
+                self.containers.insert(id, state);
             },
-            TaskDelta(task_id, delta) => {
-                if let Some(state) = self.containers.get_mut(&task_id) {
+            TaskDelta { id, delta } => {
+                if let Some(state) = self.containers.get_mut(&id) {
                     state.apply(delta);
                 }
             },

--- a/libs/sdm-launchpad/src/bus.rs
+++ b/libs/sdm-launchpad/src/bus.rs
@@ -185,14 +185,20 @@ impl LaunchpadWorker {
         // TODO: Convert to the `LaunchpadDelta` and apply
         match report.details {
             Report::State(state) => {
-                let state = LaunchpadDelta::TaskAdded(report.task_id, state);
+                let state = LaunchpadDelta::TaskAdded {
+                    id: report.task_id,
+                    state,
+                };
                 self.apply_delta(state);
             },
             Report::Delta(delta) => {
                 if report.task_id == self.wallet_task_id {
                     self.check_wallet_grpc(&delta);
                 }
-                let delta = LaunchpadDelta::TaskDelta(report.task_id, delta);
+                let delta = LaunchpadDelta::TaskDelta {
+                    id: report.task_id,
+                    delta,
+                };
                 self.apply_delta(delta);
             },
             Report::Extras(_) => {},


### PR DESCRIPTION
Description
---
Uses fields in `TaskDelta` instead of tuple-like types.

Motivation and Context
---
Tuple variants are serialized as arrays (serde behavior):

`{"TaskDelta":["Base Node",{"UpdateStatus":{data}}]}`

But access by keys is preferred for the UI:

`{"TaskDelta":{"id: "Base Node", "delta: {"UpdateStatus":{data}}}}`

How Has This Been Tested?
---
Manually
