### PR TITLE
fix: progress updates

### DIFF
--- a/cli/src/dashboard.rs
+++ b/cli/src/dashboard.rs
@@ -402,7 +402,7 @@ impl<'a, 'b> Render<'a, 'b> {
         let block = Block::default().title("Containers").borders(Borders::ALL);
         let table = Table::new(rows)
             .block(block)
-            .header(Row::new(vec!["Container", "State", "Flag"]))
+            .header(Row::new(vec!["Container", "State", "Active"]))
             .widths(&[
                 Constraint::Percentage(30),
                 Constraint::Percentage(50),

--- a/libs/sdm/src/image/checker.rs
+++ b/libs/sdm/src/image/checker.rs
@@ -105,12 +105,19 @@ pub trait ContainerChecker<P: ManagedProtocol>: Send {
     }
 }
 
-pub struct ReadyIfStarted;
+#[derive(Default)]
+pub struct ReadyIfStarted {
+    started: bool,
+}
 
 #[async_trait]
 impl<P: ManagedProtocol> ContainerChecker<P> for ReadyIfStarted {
-    async fn entrypoint(mut self: Box<Self>, ctx: CheckerContext<P>) {
-        ctx.report(CheckerEvent::Ready).ok();
+    async fn on_interval(&mut self, ctx: &mut CheckerContext<P>) -> Result<(), Error> {
+        if !self.started {
+            ctx.report(CheckerEvent::Ready)?;
+            self.started = true;
+        }
+        Ok(())
     }
 }
 

--- a/libs/sdm/src/image/mod.rs
+++ b/libs/sdm/src/image/mod.rs
@@ -36,7 +36,7 @@ pub trait ManagedContainer: fmt::Debug + Send + 'static {
     type Protocol: ManagedProtocol;
 
     fn checker(&mut self) -> Box<dyn ContainerChecker<Self::Protocol>> {
-        Box::new(ReadyIfStarted)
+        Box::new(ReadyIfStarted::default())
     }
 
     /// Reconfigures the task and return a flag should the container be active?

--- a/libs/sdm/src/image/task/docker.rs
+++ b/libs/sdm/src/image/task/docker.rs
@@ -36,7 +36,7 @@ use bollard::{
         StatsOptions,
     },
     errors::Error as BollardError,
-    image::CreateImageOptions,
+    image::{CreateImageOptions, RemoveImageOptions},
     models::{
         ContainerInspectResponse,
         CreateImageInfo,
@@ -224,6 +224,16 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
         self.driver
             .remove_container(&self.inner.container_name, Some(opts))
             .await?;
+        Ok(())
+    }
+
+    pub async fn try_remove_image(&mut self) -> Result<(), Error> {
+        let image_name = self.inner.image_name.as_ref();
+        let opts = Some(RemoveImageOptions {
+            force: true,
+            ..Default::default()
+        });
+        self.driver.remove_image(image_name, opts, None).await?;
         Ok(())
     }
 

--- a/libs/sdm/src/image/task/mod.rs
+++ b/libs/sdm/src/image/task/mod.rs
@@ -43,6 +43,10 @@ pub struct ImageTask<C: ManagedProtocol> {
     // TODO: Rename to `fqdn`
     image_name: String,
     image: Box<dyn ManagedContainer<Protocol = C>>,
+    /// A flag to ask to restart a container
+    force_restart: bool,
+    /// A flag to drop and pull image again
+    force_pull: bool,
 }
 
 impl<C: ManagedProtocol> ImageTask<C> {
@@ -55,6 +59,8 @@ impl<C: ManagedProtocol> ImageTask<C> {
             container_name,
             image_name,
             image,
+            force_restart: false,
+            force_pull: false,
         }
     }
 }
@@ -97,6 +103,12 @@ impl<C: ManagedProtocol> RunnableContext<ImageTask<C>> for TaskContext<ImageTask
     }
 }
 
+impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
+    fn should_be_restarted(&self) -> bool {
+        self.force_restart || self.force_pull
+    }
+}
+
 #[derive(Debug)]
 pub enum Status {
     InitialState,
@@ -122,6 +134,8 @@ pub enum Status {
         checker: TaskGuard<()>,
         ready: bool,
     },
+
+    DropImage,
 }
 
 impl TaskStatusChecker for Status {

--- a/libs/sdm/src/image/task/update.rs
+++ b/libs/sdm/src/image/task/update.rs
@@ -41,6 +41,7 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
             Status::StartContainer => self.do_start_container().await,
             Status::WaitContainerStarted => self.do_wait_container_started().await,
             Status::Active { .. } => self.do_active().await,
+            Status::DropImage => self.do_drop_image().await,
         }
     }
 
@@ -49,17 +50,27 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
 
         log::debug!("Cheking image {} ...", self.inner.image_name);
         if self.image_exists().await {
-            log::debug!("Image {} exists. Skip pulling.", self.inner.image_name);
-            let progress = TaskProgress::new("Cleaning...");
-            self.update_task_status(TaskStatus::Progress(progress))?;
-            self.status.set(Status::CleanDangling);
+            self.clean_dangling()?;
         } else {
-            log::debug!("Image {} doesn't exist. Pulling.", self.inner.image_name);
-            let progress = TaskProgress::new("Pulling...");
-            self.update_task_status(TaskStatus::Progress(progress))?;
-            let progress = self.pull();
-            self.status.set(Status::PullingImage { progress });
+            self.start_pulling()?;
         }
+        Ok(())
+    }
+
+    fn clean_dangling(&mut self) -> Result<(), Error> {
+        log::debug!("Image {} exists. Skip pulling.", self.inner.image_name);
+        let progress = TaskProgress::new("Cleaning...");
+        self.update_task_status(TaskStatus::Progress(progress))?;
+        self.status.set(Status::CleanDangling);
+        Ok(())
+    }
+
+    fn start_pulling(&mut self) -> Result<(), Error> {
+        log::debug!("Image {} doesn't exist. Pulling.", self.inner.image_name);
+        let progress = TaskProgress::new("Pulling...");
+        self.update_task_status(TaskStatus::Progress(progress))?;
+        let progress = self.pull();
+        self.status.set(Status::PullingImage { progress });
         Ok(())
     }
 
@@ -106,12 +117,21 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn do_idle(&mut self) -> Result<(), Error> {
-        if self.should_be_active() {
+        if self.force_pull {
+            self.force_pull = false;
+            self.status.set(Status::DropImage);
+            let progress = TaskProgress::new("Removing image...");
+            self.update_task_status(TaskStatus::Progress(progress))?;
+            Ok(())
+        } else if self.should_be_active() {
+            self.force_restart = false;
             log::debug!("Preparing a container {} to start...", self.inner.container_name);
             self.status.set(Status::CreateContainer);
             self.update_task_status(TaskStatus::Pending)?;
+            Ok(())
+        } else {
+            Ok(())
         }
-        Ok(())
     }
 
     async fn do_create_container(&mut self) -> Result<(), Error> {
@@ -134,10 +154,7 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn do_active(&mut self) -> Result<(), Error> {
-        // TODO: Spawn `ready to use` worker
-
-        // TODO: Remove the following
-        if !self.should_be_active() {
+        if !self.should_be_active() || self.should_be_restarted() {
             self.status.set(Status::CleanDangling);
         }
         Ok(())
@@ -145,5 +162,9 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
 
     async fn do_wait_container_started(&mut self) -> Result<(), Error> {
         Ok(())
+    }
+
+    async fn do_drop_image(&mut self) -> Result<(), Error> {
+        self.try_remove_image().await
     }
 }


### PR DESCRIPTION
Description
---
Fixes progress updates blinking.
Also added methods to remove images and "Flag" column renamed to "Active".

Motivation and Context
---
`Active` status sometimes temporary changes to `Progress`.
Background workers of a task used not only checks a container its ready for using, but also maintains logs and stats streams. Since the worker is not terminated to keep that streams it's necessary to skip further `Progress` events from that workers.

How Has This Been Tested?
---
Manually
