### PR TITLE
fix: prepare the code to upgrade the tari deps

### DIFF
--- a/libs/protocol/src/settings.rs
+++ b/libs/protocol/src/settings.rs
@@ -24,7 +24,6 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use tari_utilities::Hidden;
 use thiserror::Error;
 
 pub const DEFAULT_MONEROD_URL: &str = "http://stagenet.xmr-tw.org:38081,\
@@ -39,7 +38,7 @@ pub struct BaseNodeConfig {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WalletConfig {
     /// The password to de/en-crypt the wallet database
-    pub password: Hidden<String>,
+    pub password: String,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -61,8 +60,7 @@ pub struct MmProxyConfig {
     /// If required, the monero username for the monero daemon
     pub monero_username: String,
     /// If required, the password needed to access the monero deamon
-    // #[serde(skip_serializing)]
-    pub monero_password: Hidden<String>,
+    pub monero_password: String,
     /// If true, provide the monero username and password to the daemon. Otherwise those strings are ignored.
     pub monero_use_auth: bool,
 }
@@ -72,7 +70,7 @@ impl Default for MmProxyConfig {
         MmProxyConfig {
             monerod_url: DEFAULT_MONEROD_URL.to_string(),
             monero_username: String::new(),
-            monero_password: Hidden::from(String::new()),
+            monero_password: String::new(),
             monero_use_auth: false,
         }
     }
@@ -99,7 +97,7 @@ pub struct LaunchpadSettings {
     /// The Tari network to use. Default = esmeralda
     pub tari_network: TariNetwork,
     /// The tor control password to share among containers.
-    pub tor_control_password: Hidden<String>,
+    pub tor_control_password: String,
     /// Whether to spin up a base node or not, with
     /// the given configuration. Usually you want this.
     pub base_node: Option<BaseNodeConfig>,
@@ -135,7 +133,7 @@ impl Default for LaunchpadSettings {
         Self {
             data_directory: PathBuf::default(),
             tari_network: TariNetwork::Esmeralda,
-            tor_control_password: Hidden::from(String::new()),
+            tor_control_password: String::new(),
             base_node: None,
             wallet: None,
             sha3_miner: None,

--- a/libs/sdm-launchpad/src/bus.rs
+++ b/libs/sdm-launchpad/src/bus.rs
@@ -124,12 +124,12 @@ impl LaunchpadWorker {
         let data_directory = configurator.base_path().clone();
         configurator.init_configuration().await?;
         let wallet_config = WalletConfig {
-            password: "123".to_string().into(),
+            password: "123".to_string(),
         };
         let config = LaunchpadSettings {
             data_directory,
             with_monitoring: true,
-            tor_control_password: "tari".to_string().into(), // create_password(16).into(),
+            tor_control_password: "tari".to_string(), // create_password(16).into(),
             wallet: Some(wallet_config),
             ..Default::default()
         };

--- a/libs/sdm-launchpad/src/resources/config.rs
+++ b/libs/sdm-launchpad/src/resources/config.rs
@@ -33,7 +33,7 @@ pub use tari_launchpad_protocol::{
     settings::{LaunchpadSettings, TariNetwork, WalletConfig},
 };
 use tari_sdm::{config::ManagedProtocol, image::Envs};
-use tari_utilities::{ByteArray, Hidden};
+use tari_utilities::ByteArray;
 use tari_wallet_grpc_client::grpc::GetIdentityResponse;
 
 #[derive(Debug)]
@@ -104,7 +104,7 @@ impl TryFrom<GetIdentityResponse> for WalletIdentity {
 #[derive(Debug)]
 pub struct ConnectionSettings {
     pub session: LaunchpadSession,
-    pub tor_password: Hidden<String>,
+    pub tor_password: String,
     pub tari_network: TariNetwork,
     pub data_directory: PathBuf,
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,4 +13,4 @@
 # - the CI files in .github folder
 # - the Makefile in base_layer/key_manager/Makefile
 [toolchain]
-channel = "nightly-2022-05-01"
+channel = "nightly-2022-11-03"


### PR DESCRIPTION
Description
---
Two changes:
- The `rust-toolchain` is upgraded to `nightly-2022-11-03` (the same as `tari` repo uses)
- The `Hidden` wrapper removed from the configuration's fields (temporary)

Motivation and Context
---
1. The toolchain is upgraded, because the latest `tari` version uses fresh versions of crates that can't be compiled with the current toolchain: `time v0.3.20 cannot be built because it requires rustc 1.63.0 or newer`

2. The `Hidden` wrapper is removed, because the latest version of the `tari_utilities` crate doesn't implement `Serialize` for `Hidden` (reasonable), but the launchpad uses `Serialize` to send a config to the UI for editing. The first priority is upgrading the `tari` dependencies, than I could revise and decompose the configuration structs and transfer sensitive data smarter.

How Has This Been Tested?
---
CI
