### PR TITLE
ci(fix): bump 3rd party tools

### DIFF
--- a/docker_rig/monerod.Dockerfile
+++ b/docker_rig/monerod.Dockerfile
@@ -8,7 +8,7 @@
 # Binary build
 
 # https://github.com/monero-project/monero/releases
-ARG MONERO_VERSION=0.18.2.0
+ARG MONERO_VERSION=0.18.2.2
 
 # Declare stage using linux/amd64 base image
 FROM --platform=linux/amd64 bitnami/minideb:bullseye AS build-stage-amd64
@@ -18,7 +18,7 @@ ARG MONERO_ARCH=x64
 ARG MONERO_TAR=x86_64
 
 # https://github.com/monero-project/monero/releases
-ARG MONERO_AMD64_SHA256=83e6517dc9e5198228ee5af50f4bbccdb226fe69ff8dd54404dddb90a70b7322
+ARG MONERO_AMD64_SHA256=186800de18f67cca8475ce392168aabeb5709a8f8058b0f7919d7c693786d56b
 ARG MONERO_VERSION
 
 # Declare stage using linux/arm64 base image
@@ -29,7 +29,7 @@ ARG MONERO_ARCH=armv8
 ARG MONERO_TAR=aarch64
 
 # https://github.com/monero-project/monero/releases
-ARG MONERO_ARM64_SHA256=fb20eaf9b04020abdf883eb339258814742a1452653c1f5d8705d16e90413f35
+ARG MONERO_ARM64_SHA256=f3867f2865cb98ab1d18f30adfd9168f397bd07bf7c36550dfe3a2a11fc789ba
 ARG MONERO_VERSION
 
 # Declare TARGETARCH to make it available
@@ -49,9 +49,10 @@ ARG MONERO_SHA256
 ENV MONERO_SHA256=${MONERO_SHA256:-$MONERO_AMD64_SHA256}
 ENV MONERO_SHA256=${MONERO_SHA256:-$MONERO_ARM64_SHA256}
 
-RUN apt-get update && apt-get install -y \
-    curl \
-    bzip2
+RUN apt-get update && \
+    apt-get install -y \
+      curl \
+      bzip2
 
 WORKDIR /root
 
@@ -70,6 +71,9 @@ ARG BUILDPLATFORM
 ARG MONERO_VERSION
 ARG VERSION=1.0.1
 
+#COPY --chown=tari:tari --from=build-stage-download /root/monerod /usr/local/bin/monerod
+COPY --from=build-stage-download /root/monerod /usr/local/bin/monerod
+
 RUN groupadd -g 1000 tari && \
     useradd -ms /bin/bash -u 1000 -g 1000 tari && \
     mkdir -p /home/tari/.bitmonero  && \
@@ -77,8 +81,6 @@ RUN groupadd -g 1000 tari && \
 
 USER tari
 WORKDIR /home/tari
-
-COPY --chown=tari:tari --from=build-stage-download /root/monerod /usr/local/bin/monerod
 
 # blockchain location
 VOLUME /home/tari/.bitmonero

--- a/docker_rig/tor.Dockerfile
+++ b/docker_rig/tor.Dockerfile
@@ -1,6 +1,6 @@
 # Package build
 
-ARG ALPINE_VERSION=3.17
+ARG ALPINE_VERSION=3.18
 
 FROM alpine:$ALPINE_VERSION
 
@@ -8,14 +8,11 @@ ARG ALPINE_VERSION
 ARG BUILDPLATFORM
 ARG VERSION=1.0.1
 
-# https://pkgs.alpinelinux.org/packages?name=tor&branch=v3.17&repo=community&arch=&maintainer=
-ARG TOR_VERSION=0.4.7.13-r0
+# https://pkgs.alpinelinux.org/packages?name=tor&branch=v3.18&repo=community&arch=&maintainer=
+ARG TOR_VERSION=0.4.7.13-r2
 
 # Install tor with a minimum version
-RUN apk update \
- && apk upgrade \
- && apk add grep curl tor>$TOR_VERSION \
- && rm /var/cache/apk/*
+RUN apk add --no-cache grep curl tor>$TOR_VERSION
 
 ENV dockerfile_version=$VERSION
 ENV dockerfile_build_arch=$BUILDPLATFORM

--- a/docker_rig/xmrig.Dockerfile
+++ b/docker_rig/xmrig.Dockerfile
@@ -1,6 +1,6 @@
 # Source build
 
-ARG ALPINE_VERSION=3.17
+ARG ALPINE_VERSION=3.18
 
 FROM alpine:$ALPINE_VERSION as builder
 
@@ -8,7 +8,7 @@ ARG ALPINE_VERSION
 ARG BUILDPLATFORM
 
 # https://github.com/xmrig/xmrig/releases
-ARG XMRIG_VERSION="v6.19.1"
+ARG XMRIG_VERSION="v6.20.0"
 
 RUN apk add \
     git \
@@ -39,7 +39,7 @@ ARG BUILDPLATFORM
 
 ARG XMRIG_VERSION
 ARG VERSION=1.0.1
-COPY --from=builder /xmrig/build/xmrig /usr/bin/
+COPY --from=builder /xmrig/build/xmrig /usr/local/bin/
 
 # Create a user & group
 RUN addgroup -g 1000 tari && \
@@ -47,7 +47,7 @@ RUN addgroup -g 1000 tari && \
 
 # Chown all the files to the app user.
 RUN mkdir -p /home/tari && \
-    chown tari.tari /home/tari
+    chown tari:tari /home/tari
 
 USER tari
 
@@ -67,4 +67,4 @@ RUN echo -e "\
 }\
 " > /home/tari/.xmrig.json
 
-ENTRYPOINT [ "/usr/bin/xmrig" ]
+ENTRYPOINT [ "/usr/local/bin/xmrig" ]


### PR DESCRIPTION
Description
Bump 3rd party docker images

monero 0.18.2.0 -> 0.18.2.2
tor 0.4.7.13-r0 -> 0.4.7.13-r2
xmrig v6.19.1 -> v6.20.0

Motivation and Context
Update to latest releases.

How Has This Been Tested?
Built locally on Apple M1 and Apple Intel and in local fork