### PR TITLE
feat: terminate containers on exit

### DIFF
--- a/cli/src/component/main_view.rs
+++ b/cli/src/component/main_view.rs
@@ -14,6 +14,7 @@ use crate::{
         Component,
         ComponentEvent,
         Input,
+        Pass,
     },
     state::{focus, AppState},
 };
@@ -40,6 +41,14 @@ impl MainView {
 
 impl Input for MainView {
     fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+        if event.pass() == Pass::Quit {
+            let session = &mut state.state.config.session;
+            session.stop_all();
+            state.terminate();
+            state.focus_on(focus::TERMINATION);
+            state.update_state();
+            return;
+        }
         self.header.on_event(event, state);
         if state.focus_on == focus::ONBOARDING {
             self.onboarding_scene.on_event(event, state);

--- a/cli/src/component/mod.rs
+++ b/cli/src/component/mod.rs
@@ -7,11 +7,13 @@ mod normal;
 mod onboarding;
 mod settings;
 mod tabs;
+mod termination;
 mod widgets;
 
 use crossterm::event::{KeyCode, KeyEvent};
 use derive_more::From;
 pub use main_view::MainView;
+pub use termination::TerminationView;
 use tui::{backend::Backend, layout::Rect, Frame};
 
 use crate::state::AppState;
@@ -37,6 +39,7 @@ pub enum Pass {
     Next,
     Other,
     Tick,
+    Quit,
 }
 
 // impl Pass {
@@ -67,6 +70,7 @@ impl ComponentEvent {
                 KeyCode::Esc => Pass::Leave,
                 KeyCode::Enter => Pass::Enter,
                 KeyCode::Char(' ') => Pass::Space,
+                KeyCode::Char('q') => Pass::Quit,
                 KeyCode::Tab => Pass::Next,
                 _ => Pass::Other,
             },

--- a/cli/src/component/termination.rs
+++ b/cli/src/component/termination.rs
@@ -1,0 +1,33 @@
+use tui::{
+    backend::Backend,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    widgets::Paragraph,
+    Frame,
+};
+
+use crate::component::{elements::block_with_title, AppState, Component};
+
+pub struct TerminationView {}
+
+impl TerminationView {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<B: Backend> Component<B> for TerminationView {
+    type State = AppState;
+
+    fn draw(&self, f: &mut Frame<B>, rect: Rect, _state: &Self::State) {
+        let block = block_with_title(None, false);
+        let inner_rect = block.inner(rect);
+        f.render_widget(block, rect);
+        let constraints = [Constraint::Percentage(40), Constraint::Length(1)];
+        let v_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(constraints)
+            .split(inner_rect);
+        let paragraph = Paragraph::new("Terminating...").alignment(Alignment::Center);
+        f.render_widget(paragraph, v_chunks[1]);
+    }
+}

--- a/cli/src/state/focus.rs
+++ b/cli/src/state/focus.rs
@@ -7,6 +7,7 @@ macro_rules! focus {
     }};
 }
 
+pub static TERMINATION: Focus = focus!();
 pub static ONBOARDING: Focus = focus!();
 pub static ROOT: Focus = focus!();
 pub static TARI_MINING: Focus = focus!();

--- a/cli/src/state/mod.rs
+++ b/cli/src/state/mod.rs
@@ -22,6 +22,7 @@ pub struct AppState {
     pub bus: Bus,
     pub bus_tx: BusTx,
     pub state: LaunchpadState,
+    pub terminate: bool,
 }
 
 impl AppState {
@@ -32,12 +33,27 @@ impl AppState {
             bus,
             bus_tx,
             state,
+            terminate: false,
         }
+    }
+
+    pub fn is_terminated(&mut self) -> bool {
+        let has_active_task = self
+            .state
+            .containers
+            .values()
+            .filter(|state| !state.permanent)
+            .any(|state| state.status.is_started());
+        self.terminate && !has_active_task
     }
 
     pub fn focus_on(&mut self, value: Focus) {
         let event = AppEvent::SetFocus(value);
         self.events_queue.push_front(event);
+    }
+
+    pub fn terminate(&mut self) {
+        self.terminate = true;
     }
 
     pub fn redraw(&mut self) {

--- a/libs/protocol/src/container.rs
+++ b/libs/protocol/src/container.rs
@@ -108,7 +108,7 @@ impl TaskState {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskProgress {
     pub pct: u8,
     pub stage: String,
@@ -123,7 +123,7 @@ impl TaskProgress {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TaskStatus {
     Inactive,
     /// Waiting for dependencies.


### PR DESCRIPTION
Description
---
Terminates containers on exit.

Motivation and Context
---
Сontainers remain running after the application is terminated, although they should be stopped.

How Has This Been Tested?
---
Manually

