### PR TITLE
fix: use stagenet images for mining

### DIFF
--- a/cli/src/component/normal/wallet/mod.rs
+++ b/cli/src/component/normal/wallet/mod.rs
@@ -74,7 +74,7 @@ impl<B: Backend> Component<B> for WalletScene {
             .split(rect);
         // self.hint.draw(f, v_chunks[0], state);
 
-        let constraints = [Constraint::Percentage(50), Constraint::Percentage(50)];
+        let constraints = [Constraint::Percentage(70), Constraint::Percentage(30)];
         let h_chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(constraints)

--- a/cli/src/dashboard.rs
+++ b/cli/src/dashboard.rs
@@ -26,7 +26,7 @@ use std::{io::Stdout, time::Duration};
 use anyhow::Error;
 use async_trait::async_trait;
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers},
+    event::{Event, KeyCode, KeyModifiers},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -105,7 +105,7 @@ impl Actor for Dashboard {
         self.interval = Some(interval);
         enable_raw_mode()?;
         let mut stdout = std::io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(stdout, EnterAlternateScreen)?;
         let backend = CrosstermBackend::new(stdout);
         let terminal = Terminal::new(backend)?;
         self.terminal = Some(terminal);
@@ -122,7 +122,7 @@ impl Actor for Dashboard {
     async fn finalize(&mut self, _ctx: &mut ActorContext<Self>) -> Result<(), Error> {
         disable_raw_mode()?;
         let mut terminal = self.terminal.take().ok_or_else(|| DashboardError::Terminal)?;
-        execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+        execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
         terminal.show_cursor()?;
         self.supervisor.send(DashboardEvent::Terminated)?;
         Ok(())

--- a/libs/protocol/src/wallet.rs
+++ b/libs/protocol/src/wallet.rs
@@ -55,6 +55,7 @@ pub struct WalletBalance {
     pub available: u64,
     pub pending_incoming: u64,
     pub pending_outgoing: u64,
+    pub timelocked: u64,
 }
 
 impl WalletState {

--- a/libs/sdm-launchpad/src/resources/images/l3_miner.rs
+++ b/libs/sdm-launchpad/src/resources/images/l3_miner.rs
@@ -60,6 +60,10 @@ impl ManagedContainer for TariSha3Miner {
         "tari_sha3_miner"
     }
 
+    fn tag(&self) -> &str {
+        "v0.49.2_20230628_e0e4ebc"
+    }
+
     fn reconfigure(&mut self, config: Option<&LaunchpadConfig>) -> Option<bool> {
         self.settings = ConnectionSettings::try_extract(config?);
         let session = &self.settings.as_ref()?.session;

--- a/libs/sdm-launchpad/src/resources/images/l5_mmproxy.rs
+++ b/libs/sdm-launchpad/src/resources/images/l5_mmproxy.rs
@@ -62,6 +62,10 @@ impl ManagedContainer for MmProxy {
         "tari_mm_proxy"
     }
 
+    fn tag(&self) -> &str {
+        "v0.49.2_20230628_e0e4ebc"
+    }
+
     fn reconfigure(&mut self, config: Option<&LaunchpadConfig>) -> Option<bool> {
         self.settings = ConnectionSettings::try_extract(config?);
         let session = &self.settings.as_ref()?.session;

--- a/libs/sdm-launchpad/src/wallet_grpc.rs
+++ b/libs/sdm-launchpad/src/wallet_grpc.rs
@@ -141,6 +141,7 @@ impl WalletGrpcWorker {
             available: response.available_balance,
             pending_incoming: response.pending_incoming_balance,
             pending_outgoing: response.pending_outgoing_balance,
+            timelocked: response.timelocked_balance,
         };
         let delta = WalletDelta::UpdateBalance(balance);
         self.send_update(delta)

--- a/libs/sim-launchpad/src/simulator.rs
+++ b/libs/sim-launchpad/src/simulator.rs
@@ -253,6 +253,7 @@ impl Simulator {
                     available: 0,
                     pending_incoming: 0,
                     pending_outgoing: 0,
+                    timelocked: 0,
                 };
                 let delta = WalletDelta::UpdateBalance(balance);
                 self.apply_wallet_delta(delta)?;


### PR DESCRIPTION
Description
---
The images have changed to `stagenet`.
The wallet widget displays a complete breakdown of the balance, including pending and timelocked amounts.

Motivation and Context
---
Switch mining to the stagenet.

How Has This Been Tested?
---
CI, Manually
