### PR TITLE
feat: sending funds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.3.3",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,6 +2882,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -4470,7 +4495,7 @@ checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes 1.4.0",
  "heck 0.3.3",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -4489,7 +4514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4502,7 +4527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4710,15 +4735,17 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8285baa38bdc9f879d92c0e37cb562ef38aa3aeefca22b3200186bc39242d3d5"
+checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
 dependencies = [
  "bitflags 2.3.3",
  "cassowary",
- "crossterm 0.26.1",
+ "crossterm 0.27.0",
  "indoc",
+ "itertools 0.11.0",
  "paste",
+ "strum 0.25.0",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ strum = { version = "0.24.1", features = ["derive"] }
 tact = { path = "../libs/tact" }
 thiserror = "1.0.40"
 tokio = "1.28.1"
-ratatui = "0.22.0"
+ratatui = "0.23.0"
 
 tari_launchpad_protocol = { path = "../libs/protocol" }
 tari_sdm_assets = { path = "../libs/sdm-assets" }

--- a/cli/src/component/expert/containers/mod.rs
+++ b/cli/src/component/expert/containers/mod.rs
@@ -52,7 +52,9 @@ impl ContainersScene {
 }
 
 impl Input for ContainersScene {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == focus::CONTAINERS_TABLE {
             match event.pass() {
                 Pass::Up | Pass::Leave => {
@@ -61,6 +63,7 @@ impl Input for ContainersScene {
                 _ => {},
             }
         }
+        None
     }
 }
 

--- a/cli/src/component/expert/errors/mod.rs
+++ b/cli/src/component/expert/errors/mod.rs
@@ -48,7 +48,9 @@ impl ErrorsScene {
 }
 
 impl Input for ErrorsScene {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == ERRORS_TABLE {
             match event.pass() {
                 Pass::Up | Pass::Leave => {
@@ -57,6 +59,7 @@ impl Input for ErrorsScene {
                 _ => {},
             }
         }
+        None
     }
 }
 

--- a/cli/src/component/expert/logs/mod.rs
+++ b/cli/src/component/expert/logs/mod.rs
@@ -45,7 +45,9 @@ impl LogsScene {
 }
 
 impl Input for LogsScene {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == focus::LOGS_TABLE {
             match event.pass() {
                 Pass::Up | Pass::Leave => {
@@ -54,6 +56,7 @@ impl Input for LogsScene {
                 _ => {},
             }
         }
+        None
     }
 }
 

--- a/cli/src/component/expert/mod.rs
+++ b/cli/src/component/expert/mod.rs
@@ -78,7 +78,9 @@ impl ExpertScene {
 }
 
 impl Input for ExpertScene {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         self.expert_tabs.on_event(event, state);
         match self.expert_tabs.selected() {
             ExpertTabs::Performance => {},
@@ -92,6 +94,7 @@ impl Input for ExpertScene {
                 self.errors_scene.on_event(event, state);
             },
         }
+        None
     }
 }
 

--- a/cli/src/component/header/mod.rs
+++ b/cli/src/component/header/mod.rs
@@ -33,7 +33,7 @@ use ratatui::{
 
 use crate::{
     component::{Component, ComponentEvent, Frame, Input},
-    state::{focus, AppState},
+    state::AppState,
 };
 
 pub struct Header {
@@ -51,8 +51,11 @@ impl Header {
 }
 
 impl Input for Header {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         self.mode_selector.on_event(event, state);
+        None
     }
 }
 
@@ -66,8 +69,6 @@ impl<B: Backend> Component<B> for Header {
             .constraints(constraints)
             .split(rect);
         self.logo.draw(f, chunks[0], state);
-        if state.focus_on != focus::ONBOARDING {
-            self.mode_selector.draw(f, chunks[1], state);
-        }
+        self.mode_selector.draw(f, chunks[1], state);
     }
 }

--- a/cli/src/component/main_view.rs
+++ b/cli/src/component/main_view.rs
@@ -63,19 +63,17 @@ impl MainView {
 }
 
 impl Input for MainView {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if event.pass() == Pass::Quit {
             let session = &mut state.state.config.session;
             session.stop_all();
             state.terminate();
             state.focus_on(focus::TERMINATION);
             state.update_state();
-            return;
-        }
-        self.header.on_event(event, state);
-        if state.focus_on == focus::ONBOARDING {
-            self.onboarding_scene.on_event(event, state);
         } else {
+            self.header.on_event(event, state);
             match self.header.mode_selector.selected() {
                 Mode::Normal => {
                     self.normal_scene.on_event(event, state);
@@ -86,8 +84,12 @@ impl Input for MainView {
                 Mode::Settings => {
                     self.settings_scene.on_event(event, state);
                 },
+                Mode::Onboarding => {
+                    self.onboarding_scene.on_event(event, state);
+                },
             }
         }
+        None
     }
 }
 
@@ -101,20 +103,19 @@ impl<B: Backend> Component<B> for MainView {
             .constraints(constraints)
             .split(rect);
         self.header.draw(f, chunks[0], state);
-        if state.focus_on == focus::ONBOARDING {
-            self.onboarding_scene.draw(f, chunks[1], state);
-        } else {
-            match self.header.mode_selector.selected() {
-                Mode::Normal => {
-                    self.normal_scene.draw(f, chunks[1], state);
-                },
-                Mode::Expert => {
-                    self.expert_scene.draw(f, chunks[1], state);
-                },
-                Mode::Settings => {
-                    self.settings_scene.draw(f, chunks[1], state);
-                },
-            }
+        match self.header.mode_selector.selected() {
+            Mode::Normal => {
+                self.normal_scene.draw(f, chunks[1], state);
+            },
+            Mode::Expert => {
+                self.expert_scene.draw(f, chunks[1], state);
+            },
+            Mode::Settings => {
+                self.settings_scene.draw(f, chunks[1], state);
+            },
+            Mode::Onboarding => {
+                self.onboarding_scene.draw(f, chunks[1], state);
+            },
         }
     }
 }

--- a/cli/src/component/motion.rs
+++ b/cli/src/component/motion.rs
@@ -43,7 +43,9 @@ pub struct Motion<T> {
 impl<T> Input for Motion<T>
 where T: Focusable + Input
 {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         let pass = event.pass();
         if let Some(focus) = self.directions.get(&pass) {
             state.focus_on(*focus);
@@ -51,6 +53,7 @@ where T: Focusable + Input
             self.inner.on_event(event, state);
         }
         self.inner.focus(self.focus == state.focus_on);
+        None
     }
 }
 

--- a/cli/src/component/normal/base_node/container.rs
+++ b/cli/src/component/normal/base_node/container.rs
@@ -26,19 +26,21 @@ use std::time::Duration;
 use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
+    widgets::Padding,
 };
 
 use crate::{
     component::{
         elements::{block_with_title, logo},
-        normal::chrono_button::{ChronoButton, ChronoGetter},
+        widgets::{ChronoButton, ChronoGetter},
         Component,
         ComponentEvent,
         Frame,
         Input,
         Pass,
     },
-    state::{focus, AppState},
+    focus_id,
+    state::{focus, AppState, Focus},
 };
 
 const LOGO: &str = r#"
@@ -46,6 +48,8 @@ const LOGO: &str = r#"
 ╠╩╗├─┤└─┐├┤   ║║║│ │ ││├┤
 ╚═╝┴ ┴└─┘└─┘  ╝╚╝└─┘─┴┘└─┘
 "#;
+
+static BUTTON: Focus = focus_id!();
 
 struct BaseNodeGetter;
 
@@ -70,13 +74,15 @@ pub struct BaseNodeWidget {
 impl BaseNodeWidget {
     pub fn new() -> Self {
         Self {
-            button: ChronoButton::new(BaseNodeGetter),
+            button: ChronoButton::new(BaseNodeGetter, BUTTON),
         }
     }
 }
 
 impl Input for BaseNodeWidget {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == focus::BASE_NODE {
             match event.pass() {
                 Pass::Up | Pass::Leave => {
@@ -90,6 +96,7 @@ impl Input for BaseNodeWidget {
                 _ => {},
             }
         }
+        None
     }
 }
 
@@ -97,17 +104,17 @@ impl<B: Backend> Component<B> for BaseNodeWidget {
     type State = AppState;
 
     fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
-        let block = block_with_title(Some("Base Node"), state.focus_on == focus::BASE_NODE);
+        let block =
+            block_with_title(Some("Base Node"), state.focus_on == focus::BASE_NODE).padding(Padding::new(1, 1, 1, 0));
         let inner_rect = block.inner(rect);
         f.render_widget(block, rect);
 
         let constraints = [
-            Constraint::Length(1),
             Constraint::Length(3),
             // Constraint::Percentage(50),
             Constraint::Length(1),
             Constraint::Min(0),
-            Constraint::Length(1),
+            Constraint::Length(3),
         ];
         let v_chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -116,10 +123,10 @@ impl<B: Backend> Component<B> for BaseNodeWidget {
         // self.status_badge.draw(f, v_chunks[0], state);
 
         let logo = logo(LOGO);
-        f.render_widget(logo, v_chunks[1]);
+        f.render_widget(logo, v_chunks[0]);
 
-        // self.tari_amount.draw(f, v_chunks[2], state);
+        // self.tari_amount.draw(f, v_chunks[1], state);
 
-        self.button.draw(f, v_chunks[4], state);
+        self.button.draw(f, v_chunks[3], state);
     }
 }

--- a/cli/src/component/normal/base_node/mod.rs
+++ b/cli/src/component/normal/base_node/mod.rs
@@ -21,13 +21,13 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-mod widget;
+mod container;
 
+use container::BaseNodeWidget;
 use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
 };
-use widget::BaseNodeWidget;
 
 use crate::{
     component::{
@@ -67,8 +67,11 @@ impl BaseNodeScene {
 }
 
 impl Input for BaseNodeScene {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         self.base_node.on_event(event, state);
+        None
     }
 }
 

--- a/cli/src/component/normal/hint.rs
+++ b/cli/src/component/normal/hint.rs
@@ -48,7 +48,11 @@ impl<T> HintLine<T> {
 }
 
 impl<T> Input for HintLine<T> {
-    fn on_event(&mut self, _event: ComponentEvent, _state: &mut AppState) {}
+    type Output = ();
+
+    fn on_event(&mut self, _event: ComponentEvent, _state: &mut AppState) -> Option<Self::Output> {
+        None
+    }
 }
 
 impl<B: Backend, T> Component<B> for HintLine<T>

--- a/cli/src/component/normal/mining/amount.rs
+++ b/cli/src/component/normal/mining/amount.rs
@@ -50,7 +50,11 @@ impl<G> AmountIndicator<G> {
 }
 
 impl<G> Input for AmountIndicator<G> {
-    fn on_event(&mut self, _event: ComponentEvent, _state: &mut AppState) {}
+    type Output = ();
+
+    fn on_event(&mut self, _event: ComponentEvent, _state: &mut AppState) -> Option<Self::Output> {
+        None
+    }
 }
 
 impl<B: Backend, G> Component<B> for AmountIndicator<G>

--- a/cli/src/component/normal/mining/merged_mining.rs
+++ b/cli/src/component/normal/mining/merged_mining.rs
@@ -27,26 +27,26 @@ use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     style::Color,
+    widgets::Padding,
 };
 use rust_decimal::Decimal;
 
 use crate::{
     component::{
         elements::{block_with_title, logo},
-        normal::{
-            chrono_button::{ChronoButton, ChronoGetter},
-            mining::{
-                amount::{AmountGetter, AmountIndicator},
-                status_badge::{StatusBadge, StatusGetter},
-            },
+        normal::mining::{
+            amount::{AmountGetter, AmountIndicator},
+            status_badge::{StatusBadge, StatusGetter},
         },
+        widgets::{ChronoButton, ChronoGetter},
         Component,
         ComponentEvent,
         Frame,
         Input,
         Pass,
     },
-    state::{focus, AppState},
+    focus_id,
+    state::{focus, AppState, Focus},
 };
 
 const LOGO: &str = r#"
@@ -54,6 +54,8 @@ const LOGO: &str = r#"
 ║║║├┤ ├┬┘│ ┬├┤  ││  ║║║│││││││││ ┬
 ╩ ╩└─┘┴└─└─┘└─┘─┴┘  ╩ ╩┴┘└┘┴┘└┘└─┘
 "#;
+
+static BUTTON: Focus = focus_id!();
 
 struct MergedMiningGetter;
 
@@ -112,13 +114,15 @@ impl MergedMiningWidget {
             status_badge: StatusBadge::new(MergedMiningGetter),
             tari_amount: AmountIndicator::new(XtrGetter),
             monero_amount: AmountIndicator::new(XmrGetter),
-            button: ChronoButton::new(MergedMiningGetter),
+            button: ChronoButton::new(MergedMiningGetter, BUTTON),
         }
     }
 }
 
 impl Input for MergedMiningWidget {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == focus::MERGED_MINING {
             match event.pass() {
                 Pass::Left | Pass::Next => {
@@ -140,6 +144,7 @@ impl Input for MergedMiningWidget {
                 _ => {},
             }
         }
+        None
     }
 }
 
@@ -147,7 +152,8 @@ impl<B: Backend> Component<B> for MergedMiningWidget {
     type State = AppState;
 
     fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
-        let block = block_with_title(Some("Merged Mining"), state.focus_on == focus::MERGED_MINING);
+        let block = block_with_title(Some("Merged Mining"), state.focus_on == focus::MERGED_MINING)
+            .padding(Padding::horizontal(1));
         let inner_rect = block.inner(rect);
         f.render_widget(block, rect);
 
@@ -158,7 +164,7 @@ impl<B: Backend> Component<B> for MergedMiningWidget {
             Constraint::Length(1),
             Constraint::Length(1),
             Constraint::Min(0),
-            Constraint::Length(1),
+            Constraint::Length(3),
         ];
         let v_chunks = Layout::default()
             .direction(Direction::Vertical)

--- a/cli/src/component/normal/mining/mod.rs
+++ b/cli/src/component/normal/mining/mod.rs
@@ -75,9 +75,12 @@ impl MiningScene {
 }
 
 impl Input for MiningScene {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         self.tari_mining.on_event(event, state);
         self.merged_mining.on_event(event, state);
+        None
     }
 }
 

--- a/cli/src/component/normal/mining/status_badge.rs
+++ b/cli/src/component/normal/mining/status_badge.rs
@@ -49,7 +49,11 @@ impl<G> StatusBadge<G> {
 }
 
 impl<G> Input for StatusBadge<G> {
-    fn on_event(&mut self, _event: ComponentEvent, _state: &mut AppState) {}
+    type Output = ();
+
+    fn on_event(&mut self, _event: ComponentEvent, _state: &mut AppState) -> Option<Self::Output> {
+        None
+    }
 }
 
 impl<B: Backend, G> Component<B> for StatusBadge<G>

--- a/cli/src/component/normal/mining/tari_mining.rs
+++ b/cli/src/component/normal/mining/tari_mining.rs
@@ -27,26 +27,26 @@ use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     style::Color,
+    widgets::Padding,
 };
 use rust_decimal::Decimal;
 
 use crate::{
     component::{
         elements::{block_with_title, logo},
-        normal::{
-            chrono_button::{ChronoButton, ChronoGetter},
-            mining::{
-                amount::{AmountGetter, AmountIndicator},
-                status_badge::{StatusBadge, StatusGetter},
-            },
+        normal::mining::{
+            amount::{AmountGetter, AmountIndicator},
+            status_badge::{StatusBadge, StatusGetter},
         },
+        widgets::{ChronoButton, ChronoGetter},
         Component,
         ComponentEvent,
         Frame,
         Input,
         Pass,
     },
-    state::{focus, AppState},
+    focus_id,
+    state::{focus, AppState, Focus},
 };
 
 const LOGO: &str = r#"
@@ -54,6 +54,8 @@ const LOGO: &str = r#"
  ║ ├─┤├┬┘│  ║║║│││││││││ ┬
  ╩ ┴ ┴┴└─┴  ╩ ╩┴┘└┘┴┘└┘└─┘
 "#;
+
+static BUTTON: Focus = focus_id!();
 
 struct TariMiningGetter;
 
@@ -101,13 +103,15 @@ impl TariMiningWidget {
         Self {
             status_badge: StatusBadge::new(TariMiningGetter),
             tari_amount: AmountIndicator::new(XtrGetter),
-            button: ChronoButton::new(TariMiningGetter),
+            button: ChronoButton::new(TariMiningGetter, BUTTON),
         }
     }
 }
 
 impl Input for TariMiningWidget {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == focus::TARI_MINING {
             match event.pass() {
                 Pass::Right | Pass::Next => {
@@ -129,6 +133,7 @@ impl Input for TariMiningWidget {
                 _ => {},
             }
         }
+        None
     }
 }
 
@@ -136,7 +141,8 @@ impl<B: Backend> Component<B> for TariMiningWidget {
     type State = AppState;
 
     fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
-        let block = block_with_title(Some("Tari Mining"), state.focus_on == focus::TARI_MINING);
+        let block =
+            block_with_title(Some("Tari Mining"), state.focus_on == focus::TARI_MINING).padding(Padding::horizontal(1));
         let inner_rect = block.inner(rect);
         f.render_widget(block, rect);
 
@@ -146,7 +152,7 @@ impl<B: Backend> Component<B> for TariMiningWidget {
             // Constraint::Percentage(50),
             Constraint::Length(1),
             Constraint::Min(0),
-            Constraint::Length(1),
+            Constraint::Length(3),
         ];
         let v_chunks = Layout::default()
             .direction(Direction::Vertical)

--- a/cli/src/component/normal/mod.rs
+++ b/cli/src/component/normal/mod.rs
@@ -22,7 +22,6 @@
 //
 
 mod base_node;
-mod chrono_button;
 mod hint;
 mod mining;
 mod wallet;
@@ -39,6 +38,7 @@ use wallet::WalletScene;
 
 use crate::{
     component::{
+        normal::wallet::WALLET_CONTAINER,
         tabs::{AppTabs, TabGetter},
         Component,
         ComponentEvent,
@@ -70,7 +70,7 @@ impl TabGetter for NormalTabs {
         match self {
             Self::Mining => focus::TARI_MINING,
             Self::BaseNode => focus::BASE_NODE,
-            Self::Wallet => focus::WALLET_CONTAINER,
+            Self::Wallet => WALLET_CONTAINER,
         }
     }
 }
@@ -94,7 +94,9 @@ impl NormalScene {
 }
 
 impl Input for NormalScene {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         self.normal_tabs.on_event(event, state);
         match self.normal_tabs.selected() {
             NormalTabs::Mining => {
@@ -107,6 +109,7 @@ impl Input for NormalScene {
                 self.wallet_scene.on_event(event, state);
             },
         }
+        None
     }
 }
 

--- a/cli/src/component/normal/wallet/balance.rs
+++ b/cli/src/component/normal/wallet/balance.rs
@@ -26,11 +26,19 @@ use std::borrow::Cow;
 use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
-    widgets::{Row, Table},
+    widgets::{Padding, Row, Table},
 };
 
 use crate::{
-    component::{elements::block_with_title, Component, ComponentEvent, Frame, Input, Pass},
+    component::{
+        elements::block_with_title,
+        normal::wallet::{SEND_FUNDS, WALLET_CONTAINER},
+        Component,
+        ComponentEvent,
+        Frame,
+        Input,
+        Pass,
+    },
     focus_id,
     state::{
         focus::{self, Focus},
@@ -49,7 +57,9 @@ impl BalanceWidget {
 }
 
 impl Input for BalanceWidget {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == BALANCE {
             // TODO: Set focus to the particular value
             // self.password.set_focus(true);
@@ -57,12 +67,19 @@ impl Input for BalanceWidget {
                 Pass::Up | Pass::Leave => {
                     state.focus_on(focus::ROOT);
                 },
+                Pass::Left => {
+                    state.focus_on(WALLET_CONTAINER);
+                },
+                Pass::Down | Pass::Right | Pass::Next => {
+                    state.focus_on(SEND_FUNDS);
+                },
                 Pass::Enter | Pass::Space => {
                     // TODO: Toggle the base node state
                 },
                 _ => {},
             }
         }
+        None
     }
 }
 
@@ -70,18 +87,16 @@ impl<B: Backend> Component<B> for BalanceWidget {
     type State = AppState;
 
     fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
-        let block = block_with_title(Some("Balance"), state.focus_on == BALANCE);
+        let block = block_with_title(Some("Balance"), state.focus_on == BALANCE).padding(Padding::uniform(1));
         let inner_rect = block.inner(rect);
         f.render_widget(block, rect);
 
         let constraints = [
-            Constraint::Length(1),
             Constraint::Length(4),
             // Constraint::Percentage(50),
             Constraint::Length(1),
             Constraint::Min(0),
             Constraint::Length(3),
-            Constraint::Length(1),
         ];
         let v_chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -107,7 +122,7 @@ impl<B: Backend> Component<B> for BalanceWidget {
         let table = Table::new(rows)
             .widths(&[Constraint::Percentage(40), Constraint::Percentage(60)])
             .column_spacing(2);
-        f.render_widget(table, v_chunks[1]);
+        f.render_widget(table, v_chunks[0]);
     }
 }
 

--- a/cli/src/component/normal/wallet/mod.rs
+++ b/cli/src/component/normal/wallet/mod.rs
@@ -24,14 +24,19 @@
 mod balance;
 mod container;
 mod password;
+mod send_funds;
 
 use balance::BalanceWidget;
+pub use balance::BALANCE;
 use container::WalletContainerWidget;
+pub use container::WALLET_CONTAINER;
 use password::PasswordWidget;
 use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
 };
+use send_funds::SendFundsWidget;
+pub use send_funds::SEND_FUNDS;
 
 use crate::{
     component::{Component, ComponentEvent, Frame, Input},
@@ -42,6 +47,7 @@ pub struct WalletScene {
     password: PasswordWidget,
     container: WalletContainerWidget,
     balance: BalanceWidget,
+    send_funds: SendFundsWidget,
 }
 
 impl WalletScene {
@@ -50,16 +56,21 @@ impl WalletScene {
             password: PasswordWidget::new(),
             container: WalletContainerWidget::new(),
             balance: BalanceWidget::new(),
+            send_funds: SendFundsWidget::new(),
         }
     }
 }
 
 impl Input for WalletScene {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         // TODO: Check the wallet is locked/unlocked
         self.container.on_event(event, state);
         self.password.on_event(event, state);
         self.balance.on_event(event, state);
+        self.send_funds.on_event(event, state);
+        None
     }
 }
 
@@ -67,20 +78,20 @@ impl<B: Backend> Component<B> for WalletScene {
     type State = AppState;
 
     fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
-        let constraints = [Constraint::Length(1), Constraint::Percentage(50), Constraint::Min(0)];
+        let constraints = [Constraint::Length(1), Constraint::Percentage(40), Constraint::Min(0)];
         let v_chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints(constraints)
             .split(rect);
         // self.hint.draw(f, v_chunks[0], state);
 
-        let constraints = [Constraint::Percentage(70), Constraint::Percentage(30)];
+        let constraints = [Constraint::Percentage(60), Constraint::Percentage(40)];
         let h_chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(constraints)
             .split(v_chunks[1]);
         self.container.draw(f, h_chunks[0], state);
         self.balance.draw(f, h_chunks[1], state);
-        // self.password.draw(f, h_chunks[0], state);
+        self.send_funds.draw(f, v_chunks[2], state);
     }
 }

--- a/cli/src/component/normal/wallet/password.rs
+++ b/cli/src/component/normal/wallet/password.rs
@@ -31,8 +31,7 @@ use ratatui::{
 use crate::{
     component::{
         elements::{block_with_title, logo},
-        normal::chrono_button::{ChronoButton, ChronoGetter},
-        widgets::LabeledInput,
+        widgets::{ChronoButton, ChronoGetter, LabeledInput},
         Component,
         ComponentEvent,
         Frame,
@@ -53,6 +52,7 @@ const LOGO: &str = r#"
 "#;
 
 static PASSWORD_FIELD: Focus = focus_id!();
+static BUTTON: Focus = focus_id!();
 
 struct PasswordWidgetGetter;
 
@@ -79,13 +79,15 @@ impl PasswordWidget {
     pub fn new() -> Self {
         Self {
             password: LabeledInput::new("Password", PASSWORD_FIELD),
-            button: ChronoButton::new(PasswordWidgetGetter),
+            button: ChronoButton::new(PasswordWidgetGetter, BUTTON),
         }
     }
 }
 
 impl Input for PasswordWidget {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == focus::PASSWORD {
             // TODO: Set focus to the particular value
             // self.password.set_focus(true);
@@ -99,6 +101,7 @@ impl Input for PasswordWidget {
                 _ => {},
             }
         }
+        None
     }
 }
 

--- a/cli/src/component/normal/wallet/send_funds.rs
+++ b/cli/src/component/normal/wallet/send_funds.rs
@@ -1,0 +1,238 @@
+// Copyright 2023. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+use anyhow::Error;
+use ratatui::{
+    backend::Backend,
+    layout::{Constraint, Direction, Layout, Rect},
+};
+use tari_launchpad_protocol::wallet::{TransferFunds, WalletAction};
+
+use crate::{
+    component::{
+        elements::block_with_title,
+        normal::wallet::{BALANCE, WALLET_CONTAINER},
+        widgets::{ChronoButton, ChronoGetter, LabeledInput, ModalDialog},
+        Component,
+        ComponentEvent,
+        Frame,
+        Input,
+        Pass,
+    },
+    focus_id,
+    state::{focus::Focus, AppState},
+};
+
+pub static SEND_FUNDS: Focus = focus_id!();
+static ADDRESS: Focus = focus_id!();
+static AMOUNT: Focus = focus_id!();
+static FEE: Focus = focus_id!();
+static MESSAGE: Focus = focus_id!();
+static BUTTON: Focus = focus_id!();
+static DIALOG: Focus = focus_id!();
+
+struct SendFundsGetter;
+
+impl ChronoGetter for SendFundsGetter {
+    fn get_label(&self, _state: &AppState) -> &str {
+        "Send"
+    }
+}
+
+pub struct SendFundsWidget {
+    // TODO: Validation is possible here
+    address: LabeledInput<String>,
+    amount: LabeledInput<u64>,
+    fee: LabeledInput<u64>,
+    message: LabeledInput<String>,
+    button: ChronoButton<SendFundsGetter>,
+    dialog: ModalDialog,
+}
+
+impl SendFundsWidget {
+    pub fn new() -> Self {
+        Self {
+            address: LabeledInput::new("To", ADDRESS),
+            amount: LabeledInput::new_with_filter("Amount", AMOUNT, char::is_numeric),
+            fee: LabeledInput::new_with_filter("Fee", FEE, char::is_numeric),
+            message: LabeledInput::new("Message", MESSAGE),
+            button: ChronoButton::new(SendFundsGetter, BUTTON),
+            dialog: ModalDialog::new(DIALOG),
+        }
+    }
+}
+
+impl Input for SendFundsWidget {
+    type Output = ();
+
+    // TODO: Split to separate methods
+    #[allow(clippy::too_many_lines)]
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
+        if state.focus_on == SEND_FUNDS {
+            match event.pass() {
+                Pass::Up | Pass::Leave => {
+                    state.focus_on(WALLET_CONTAINER);
+                },
+                Pass::Enter | Pass::Down | Pass::Right => {
+                    state.focus_on(ADDRESS);
+                },
+                Pass::Left => {
+                    state.focus_on(BALANCE);
+                },
+                _ => {},
+            }
+        } else if state.focus_on == ADDRESS {
+            let released = self.address.is_released();
+            match event.pass() {
+                Pass::Up | Pass::Leave | Pass::Left if released => {
+                    state.focus_on(SEND_FUNDS);
+                },
+                Pass::Down | Pass::Right if released => {
+                    state.focus_on(AMOUNT);
+                },
+                _ => {
+                    self.address.on_event(event, state);
+                },
+            }
+        } else if state.focus_on == AMOUNT {
+            let released = self.amount.is_released();
+            match event.pass() {
+                Pass::Leave if released => {
+                    state.focus_on(SEND_FUNDS);
+                },
+                Pass::Up | Pass::Left if released => {
+                    state.focus_on(ADDRESS);
+                },
+                Pass::Down | Pass::Right if released => {
+                    state.focus_on(FEE);
+                },
+                _ => {
+                    self.amount.on_event(event, state);
+                },
+            }
+        } else if state.focus_on == FEE {
+            let released = self.fee.is_released();
+            match event.pass() {
+                Pass::Leave if released => {
+                    state.focus_on(SEND_FUNDS);
+                },
+                Pass::Up | Pass::Left if released => {
+                    state.focus_on(AMOUNT);
+                },
+                Pass::Down | Pass::Right if released => {
+                    state.focus_on(MESSAGE);
+                },
+                _ => {
+                    self.fee.on_event(event, state);
+                },
+            }
+        } else if state.focus_on == MESSAGE {
+            let released = self.message.is_released();
+            match event.pass() {
+                Pass::Leave if released => {
+                    state.focus_on(SEND_FUNDS);
+                },
+                Pass::Up | Pass::Left if released => {
+                    state.focus_on(FEE);
+                },
+                Pass::Down | Pass::Right if released => {
+                    state.focus_on(BUTTON);
+                },
+                _ => {
+                    self.message.on_event(event, state);
+                },
+            }
+        } else if state.focus_on == BUTTON {
+            match event.pass() {
+                Pass::Leave => {
+                    state.focus_on(SEND_FUNDS);
+                },
+                Pass::Up | Pass::Left => {
+                    state.focus_on(MESSAGE);
+                },
+                Pass::Down | Pass::Right => {
+                    state.focus_on(SEND_FUNDS);
+                },
+                Pass::Enter => match self.get_transfer() {
+                    Ok(action) => {
+                        let wallet_action = WalletAction::TransferFunds(action);
+                        state.send_action(wallet_action);
+                        self.dialog.show_success(state, &"Transaction Sent");
+                    },
+                    Err(err) => {
+                        self.dialog.show_error(state, &err);
+                    },
+                },
+                _ => {
+                    self.button.on_event(event, state);
+                },
+            }
+        } else if state.focus_on == DIALOG {
+            self.dialog.on_event(event, state);
+        } else {
+            //
+        }
+        None
+    }
+}
+
+impl SendFundsWidget {
+    fn get_transfer(&self) -> Result<TransferFunds, Error> {
+        Ok(TransferFunds {
+            address: self.address.value()?.clone(),
+            amount: *self.amount.value()?,
+            fee: *self.fee.value()?,
+            message: self.message.value()?.clone(),
+        })
+    }
+}
+
+impl<B: Backend> Component<B> for SendFundsWidget {
+    type State = AppState;
+
+    fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
+        let block = block_with_title(Some("Send Funds"), state.focus_on == SEND_FUNDS);
+        let inner_rect = block.inner(rect);
+        let constraints = [
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ];
+        let chunks = Layout::default()
+            .vertical_margin(1)
+            .horizontal_margin(3)
+            .direction(Direction::Vertical)
+            .constraints(constraints)
+            .split(inner_rect);
+        self.address.draw(f, chunks[0], state);
+        self.amount.draw(f, chunks[1], state);
+        self.fee.draw(f, chunks[2], state);
+        self.message.draw(f, chunks[3], state);
+        self.button.draw(f, chunks[4], state);
+        f.render_widget(block, rect);
+        self.dialog.draw(f, f.size(), state);
+    }
+}

--- a/cli/src/component/onboarding/message.rs
+++ b/cli/src/component/onboarding/message.rs
@@ -43,7 +43,11 @@ impl MessageWidget {
 }
 
 impl Input for MessageWidget {
-    fn on_event(&mut self, _event: ComponentEvent, _state: &mut AppState) {}
+    type Output = ();
+
+    fn on_event(&mut self, _event: ComponentEvent, _state: &mut AppState) -> Option<Self::Output> {
+        None
+    }
 }
 
 impl<B: Backend> Component<B> for MessageWidget {

--- a/cli/src/component/onboarding/mod.rs
+++ b/cli/src/component/onboarding/mod.rs
@@ -52,7 +52,9 @@ impl OnboardingScene {
 }
 
 impl Input for OnboardingScene {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if let Some(wink) = self.wink {
             if wink.elapsed() >= Duration::from_secs(5) {
                 self.wink.take();
@@ -76,6 +78,8 @@ impl Input for OnboardingScene {
             },
             _ => {},
         }
+
+        None
     }
 }
 

--- a/cli/src/component/settings/base_node.rs
+++ b/cli/src/component/settings/base_node.rs
@@ -61,14 +61,24 @@ impl BaseNodeSettings {
 }
 
 impl Input for BaseNodeSettings {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == BASE_NODE_SETTINGS {
-            state.focus_on(ROOT_FOLDER);
+            match event.pass() {
+                Pass::Up | Pass::Leave => {
+                    state.focus_on(focus::ROOT);
+                },
+                Pass::Down | Pass::Enter => {
+                    state.focus_on(ROOT_FOLDER);
+                },
+                _ => {},
+            }
         } else if state.focus_on == ROOT_FOLDER {
             let released = self.root_folder.is_released();
             match event.pass() {
-                Pass::Up | Pass::Leave if released => {
-                    state.focus_on(focus::ROOT);
+                Pass::Up | Pass::Down | Pass::Leave if released => {
+                    state.focus_on(BASE_NODE_SETTINGS);
                 },
                 _ => {
                     self.root_folder.on_event(event, state);
@@ -77,6 +87,7 @@ impl Input for BaseNodeSettings {
         } else {
             //
         }
+        None
     }
 }
 
@@ -84,7 +95,7 @@ impl<B: Backend> Component<B> for BaseNodeSettings {
     type State = AppState;
 
     fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
-        let block = block_with_title(Some("BaseNode Settings"), false);
+        let block = block_with_title(Some("BaseNode Settings"), state.focus_on == BASE_NODE_SETTINGS);
         let inner_rect = block.inner(rect);
         f.render_widget(block, rect);
         let constraints = [Constraint::Length(1), Constraint::Length(3), Constraint::Min(0)];

--- a/cli/src/component/settings/logs.rs
+++ b/cli/src/component/settings/logs.rs
@@ -61,14 +61,24 @@ impl LogsSettings {
 }
 
 impl Input for LogsSettings {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == LOGS_SETTINGS {
-            state.focus_on(MAX_SIZE);
+            match event.pass() {
+                Pass::Up | Pass::Leave => {
+                    state.focus_on(focus::ROOT);
+                },
+                Pass::Down | Pass::Enter => {
+                    state.focus_on(MAX_SIZE);
+                },
+                _ => {},
+            }
         } else if state.focus_on == MAX_SIZE {
             let released = self.max_size.is_released();
             match event.pass() {
-                Pass::Up | Pass::Leave if released => {
-                    state.focus_on(focus::ROOT);
+                Pass::Up | Pass::Down | Pass::Leave if released => {
+                    state.focus_on(LOGS_SETTINGS);
                 },
                 _ => {
                     self.max_size.on_event(event, state);
@@ -77,6 +87,7 @@ impl Input for LogsSettings {
         } else {
             //
         }
+        None
     }
 }
 
@@ -84,7 +95,7 @@ impl<B: Backend> Component<B> for LogsSettings {
     type State = AppState;
 
     fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
-        let block = block_with_title(Some("Logs Settings"), false);
+        let block = block_with_title(Some("Logs Settings"), state.focus_on == LOGS_SETTINGS);
         let inner_rect = block.inner(rect);
         f.render_widget(block, rect);
         let constraints = [

--- a/cli/src/component/settings/mod.rs
+++ b/cli/src/component/settings/mod.rs
@@ -99,7 +99,9 @@ impl SettingsScene {
 }
 
 impl Input for SettingsScene {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         self.settings_tabs.on_event(event, state);
         match self.settings_tabs.selected() {
             SettingsTabs::Mining => {
@@ -121,6 +123,7 @@ impl Input for SettingsScene {
                 self.security_settings.on_event(event, state);
             },
         }
+        None
     }
 }
 

--- a/cli/src/component/settings/security.rs
+++ b/cli/src/component/settings/security.rs
@@ -24,9 +24,15 @@
 use ratatui::{backend::Backend, layout::Rect};
 
 use crate::{
-    component::{elements::block_with_title, Component, ComponentEvent, Frame, Input},
-    state::AppState,
+    component::{elements::block_with_title, Component, ComponentEvent, Frame, Input, Pass},
+    focus_id,
+    state::{
+        focus::{self, Focus},
+        AppState,
+    },
 };
+
+pub static SECURITY_SETTINGS: Focus = focus_id!();
 
 pub struct SecuritySettings {}
 
@@ -37,14 +43,29 @@ impl SecuritySettings {
 }
 
 impl Input for SecuritySettings {
-    fn on_event(&mut self, _event: ComponentEvent, _state: &mut AppState) {}
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
+        if state.focus_on == SECURITY_SETTINGS {
+            match event.pass() {
+                Pass::Up | Pass::Leave => {
+                    state.focus_on(focus::ROOT);
+                },
+                Pass::Down | Pass::Enter => {
+                    // TODO:
+                },
+                _ => {},
+            }
+        }
+        None
+    }
 }
 
 impl<B: Backend> Component<B> for SecuritySettings {
     type State = AppState;
 
-    fn draw(&self, f: &mut Frame<B>, rect: Rect, _state: &Self::State) {
-        let block = block_with_title(Some("Security Settings"), false);
+    fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
+        let block = block_with_title(Some("Security Settings"), state.focus_on == SECURITY_SETTINGS);
         f.render_widget(block, rect);
     }
 }

--- a/cli/src/component/settings/wallet.rs
+++ b/cli/src/component/settings/wallet.rs
@@ -51,14 +51,24 @@ impl WalletSettings {
 }
 
 impl Input for WalletSettings {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == WALLET_SETTINGS {
-            state.focus_on(WALLET_ID);
+            match event.pass() {
+                Pass::Up | Pass::Leave => {
+                    state.focus_on(focus::ROOT);
+                },
+                Pass::Down | Pass::Enter => {
+                    state.focus_on(WALLET_ID);
+                },
+                _ => {},
+            }
         } else if state.focus_on == WALLET_ID {
             let released = self.wallet_id.is_released();
             match event.pass() {
-                Pass::Up | Pass::Leave if released => {
-                    state.focus_on(focus::ROOT);
+                Pass::Up | Pass::Down | Pass::Leave if released => {
+                    state.focus_on(WALLET_SETTINGS);
                 },
                 _ => {
                     self.wallet_id.on_event(event, state);
@@ -67,6 +77,7 @@ impl Input for WalletSettings {
         } else {
             //
         }
+        None
     }
 }
 
@@ -74,7 +85,7 @@ impl<B: Backend> Component<B> for WalletSettings {
     type State = AppState;
 
     fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
-        let block = block_with_title(Some("Wallet Settings"), false);
+        let block = block_with_title(Some("Wallet Settings"), state.focus_on == WALLET_SETTINGS);
         let inner_rect = block.inner(rect);
         f.render_widget(block, rect);
         let constraints = [Constraint::Length(3), Constraint::Min(0)];

--- a/cli/src/component/tabs.rs
+++ b/cli/src/component/tabs.rs
@@ -91,7 +91,9 @@ impl<T> AppTabs<T> {
 impl<T> Input for AppTabs<T>
 where T: TabGetter
 {
-    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if state.focus_on == self.focus_on {
             match event.pass() {
                 Pass::Next | Pass::Right => {
@@ -107,6 +109,7 @@ where T: TabGetter
                 _ => {},
             }
         }
+        None
     }
 }
 

--- a/cli/src/component/widgets/dialog.rs
+++ b/cli/src/component/widgets/dialog.rs
@@ -1,0 +1,171 @@
+// Copyright 2023. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+};
+
+use crate::{
+    component::{AppState, Backend, Component, ComponentEvent, Frame, Input, Pass, Rect},
+    state::Focus,
+};
+
+pub struct ModalDialog {
+    focus: Focus,
+    focus_back: Option<Focus>,
+    title: String,
+    message: String,
+    color: Color,
+    width_pct: u16,
+    height_pct: u16,
+}
+
+impl ModalDialog {
+    pub fn new(focus: Focus) -> Self {
+        Self {
+            focus,
+            focus_back: None,
+            title: String::new(),
+            message: String::new(),
+            color: Color::White,
+            width_pct: 50,
+            height_pct: 10,
+        }
+    }
+
+    pub fn show_error(&mut self, state: &mut AppState, msg: &dyn ToString) {
+        self.focus_back = Some(state.focus_on);
+        self.message = msg.to_string();
+        self.color = Color::Red;
+        state.focus_on(self.focus);
+    }
+
+    pub fn show_success(&mut self, state: &mut AppState, msg: &dyn ToString) {
+        self.focus_back = Some(state.focus_on);
+        self.message = msg.to_string();
+        self.color = Color::Green;
+        state.focus_on(self.focus);
+    }
+}
+
+impl Input for ModalDialog {
+    type Output = ();
+
+    fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
+        if state.focus_on == self.focus {
+            match event.pass() {
+                Pass::Leave | Pass::Enter => {
+                    // Changing focus back closes the dialog
+                    let focus = self.focus_back.take()?;
+                    state.focus_on(focus);
+                },
+                _ => {},
+            }
+        }
+        None
+    }
+}
+
+impl<B: Backend> Component<B> for ModalDialog {
+    type State = AppState;
+
+    fn draw(&self, f: &mut Frame<B>, rect: Rect, state: &Self::State) {
+        if state.focus_on == self.focus {
+            self.draw_dialog(f, rect);
+        }
+    }
+}
+
+impl ModalDialog {
+    fn draw_dialog<B>(&self, f: &mut Frame<B>, full_area: Rect)
+    where B: Backend {
+        let color = self.color;
+        let width = self.width_pct * full_area.width / 100;
+        let height = self.height_pct * full_area.height / 100;
+        let popup_area = centered_rect_absolute(width, height, full_area);
+
+        f.render_widget(Clear, popup_area);
+
+        let block = Block::default().borders(Borders::ALL).title(Span::styled(
+            &self.title,
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ));
+        f.render_widget(block, popup_area);
+
+        let lines = self.message.lines();
+
+        let mut spans = Vec::new();
+        for line in lines {
+            spans.push(Line::from(Span::styled(
+                line,
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            )));
+        }
+        let center_area = centered_rect_absolute(
+            width.min(full_area.width).saturating_sub(2),
+            ((spans.len()) as u16).clamp(2, full_area.height),
+            full_area,
+        );
+
+        let text = Paragraph::new(spans)
+            .style(Style::default().fg(color))
+            .block(Block::default())
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true });
+
+        f.render_widget(text, center_area);
+    }
+}
+
+// TODO: Move to the shared crate (borrowed from the `tari_console_wallet`)
+/// Help function to create a centered rectangle with absolute dimensions
+pub fn centered_rect_absolute(width: u16, height: u16, r: Rect) -> Rect {
+    let vertical_pad = r.height.saturating_sub(height) / 2;
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(
+            [
+                Constraint::Length(vertical_pad),
+                Constraint::Length(height.min(r.height)),
+                Constraint::Min(1),
+            ]
+            .as_ref(),
+        )
+        .split(r);
+
+    let horizontal_pad = r.width.saturating_sub(width) / 2;
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(
+            [
+                Constraint::Length(horizontal_pad),
+                Constraint::Length(width.min(r.width)),
+                Constraint::Min(1),
+            ]
+            .as_ref(),
+        )
+        .split(popup_layout[1])[1]
+}

--- a/cli/src/component/widgets/mod.rs
+++ b/cli/src/component/widgets/mod.rs
@@ -21,10 +21,14 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
+mod chrono_button;
+mod dialog;
 mod label;
 mod labeled_input;
 mod separator;
 
+pub use chrono_button::{ButtonAction, ChronoButton, ChronoGetter};
+pub use dialog::ModalDialog;
 pub use label::Label;
 pub use labeled_input::LabeledInput;
 pub use separator::Separator;

--- a/cli/src/state/focus.rs
+++ b/cli/src/state/focus.rs
@@ -32,13 +32,11 @@ macro_rules! focus_id {
 }
 
 pub static TERMINATION: Focus = focus_id!();
-pub static ONBOARDING: Focus = focus_id!();
 pub static ROOT: Focus = focus_id!();
 pub static TARI_MINING: Focus = focus_id!();
 pub static MERGED_MINING: Focus = focus_id!();
 pub static BASE_NODE: Focus = focus_id!();
 pub static PASSWORD: Focus = focus_id!();
-pub static WALLET_CONTAINER: Focus = focus_id!();
 
 pub static LOGS_TABLE: Focus = focus_id!();
 pub static CONTAINERS_TABLE: Focus = focus_id!();

--- a/libs/protocol/src/launchpad.rs
+++ b/libs/protocol/src/launchpad.rs
@@ -32,7 +32,7 @@ use crate::{
     frame::Frame,
     session::LaunchpadSession,
     settings::LaunchpadSettings,
-    wallet::{WalletDelta, WalletState},
+    wallet::{WalletAction, WalletDelta, WalletState},
 };
 
 /// An action sent from UI to the backend.
@@ -45,6 +45,7 @@ pub enum Action {
 pub enum LaunchpadAction {
     Connect,
     ChangeSession(LaunchpadSession),
+    WalletAction(WalletAction),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -76,6 +77,7 @@ impl Default for LaunchpadState {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Reaction {
     State(LaunchpadState),

--- a/libs/protocol/src/wallet.rs
+++ b/libs/protocol/src/wallet.rs
@@ -28,11 +28,14 @@ use serde::{Deserialize, Serialize};
 const HISTORY_LIMIT: usize = 30;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WalletId(pub String);
+pub struct MyIdentity {
+    pub tari_address: String,
+    pub emoji_id: String,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletState {
-    pub wallet_id: Option<WalletId>,
+    pub wallet_id: Option<MyIdentity>,
     /// If wallet is active transactions could be sent.
     pub active: bool,
     pub balance: Option<WalletBalance>,
@@ -50,7 +53,7 @@ impl Default for WalletState {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct WalletBalance {
     pub available: u64,
     pub pending_incoming: u64,
@@ -85,7 +88,7 @@ impl WalletState {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WalletDelta {
-    SetAddress(WalletId),
+    SetAddress(MyIdentity),
     SetActive(bool),
     UpdateBalance(WalletBalance),
     LogTransaction(WalletTransaction),
@@ -95,8 +98,6 @@ pub enum WalletDelta {
 pub struct WalletTransaction {
     pub event: String,
     pub tx_id: String,
-    // pub source_pk: Vec<u8>,
-    // pub dest_pk: Vec<u8>,
     pub status: String,
     pub direction: String,
     pub amount: u64,
@@ -106,5 +107,13 @@ pub struct WalletTransaction {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WalletAction {
-    TransferFunds,
+    TransferFunds(TransferFunds),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferFunds {
+    pub address: String,
+    pub amount: u64,
+    pub fee: u64,
+    pub message: String,
 }

--- a/libs/sdm-launchpad/src/bus.rs
+++ b/libs/sdm-launchpad/src/bus.rs
@@ -45,7 +45,6 @@ pub type BusTx = mpsc::UnboundedSender<Action>;
 pub type BusRx = mpsc::UnboundedReceiver<Reaction>;
 
 pub struct LaunchpadBus {
-    // pub handle: JoinHandle<()>,
     pub incoming: mpsc::UnboundedSender<Action>,
     pub outgoing: mpsc::UnboundedReceiver<Reaction>,
 }
@@ -174,6 +173,11 @@ impl LaunchpadWorker {
                 self.apply_delta(LaunchpadDelta::UpdateSession(session));
                 let config = self.state.config.clone();
                 self.scope.set_config(Some(config))?;
+            },
+            LaunchpadAction::WalletAction(action) => {
+                if let Some(grpc) = self.wallet_grpc.as_mut() {
+                    grpc.send_action(action)?;
+                }
             },
         }
         Ok(())

--- a/libs/sim-launchpad/src/bus.rs
+++ b/libs/sim-launchpad/src/bus.rs
@@ -28,6 +28,10 @@ use tokio::sync::mpsc;
 use crate::simulator::Simulator;
 
 // TODO: Move (join) this `Bus` with the main sdm bus
+
+pub type BusTx = mpsc::UnboundedSender<Action>;
+pub type BusRx = mpsc::UnboundedReceiver<Reaction>;
+
 pub struct LaunchpadBus {
     pub incoming: mpsc::UnboundedSender<Action>,
     pub outgoing: mpsc::UnboundedReceiver<Reaction>,


### PR DESCRIPTION
Description
---
Changes:
- Upgraded ratatui dependency to version 0.23.0
- Added the ability to select between various modes, including `Bot`
- Implemented global app termination using `Ctrl-Q`
- Enhanced UI: buttons are now focusable
- Introduced the `SendFunds` widget
- Enabled forwarding of send funds messages to a bus system
- Improved user experience in settings: added focus navigation between tabs
- Integrated the `ModalDialog` widget
- The field widget has been enhanced to support value extraction and replacement
- Integrated GRPC client (worker) support for receiving "send funds" messages (to forward to a container)
- Mining settings can now be updated from a config file
- Enhanced display capability to render all wallet address formats

Motivation and Context
---
Implement **send funds** feature

How Has This Been Tested?
---
CI, manually

