### PR TITLE
chore: update containers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Node.js setup
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: "20"
           cache: 'yarn'
 
       - name: Rust setup (native)

--- a/.github/workflows/reusable-ci-jobs.yml
+++ b/.github/workflows/reusable-ci-jobs.yml
@@ -109,9 +109,9 @@
               - name: Cache rust dependencies
                 uses: Swatinem/rust-cache@v1
               - name: setup node
-                uses: actions/setup-node@v3
+                uses: actions/setup-node@v4
                 with:
-                    node-version: "16"
+                    node-version: "20"
               - name: ubuntu dependencies
                 if: ${{ inputs.build-tari }}
                 run: |
@@ -152,9 +152,9 @@
           - name: checkout
             uses: actions/checkout@v2
           - name: setup node
-            uses: actions/setup-node@v3
+            uses: actions/setup-node@v4
             with:
-              node-version: "16"
+              node-version: "20"
           - name: Install Yarn
             run: npm install -g yarn
           - name: log javascript environment

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -24,9 +24,9 @@ jobs:
       - name: toolchain
         uses: actions-rs/toolchain@v1
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
       - uses: Swatinem/rust-cache@v1
       - name: ubuntu dependencies
         run: |

--- a/backend/src/docker/models.rs
+++ b/backend/src/docker/models.rs
@@ -142,36 +142,36 @@ impl From<LogOutput> for LogMessage {
 /// Supported networks for the launchpad
 #[derive(Serialize, Debug, Deserialize, Clone, Copy)]
 pub enum TariNetwork {
-    Dibbler,
-    Esmeralda,
     Igor,
+    Nextnet,
+    Stagenet,
     Mainnet,
 }
 
 impl TariNetwork {
     pub fn lower_case(self) -> &'static str {
         match self {
-            Self::Dibbler => "dibbler",
-            Self::Esmeralda => "esmeralda",
             Self::Igor => "igor",
+            Self::Nextnet => "nextnet",
+            Self::Stagenet => "stagenet",
             Self::Mainnet => "mainnet",
         }
     }
 
     pub fn upper_case(self) -> &'static str {
         match self {
-            Self::Dibbler => "DIBBLER",
-            Self::Esmeralda => "ESMERALDA",
             Self::Igor => "IGOR",
+            Self::Nextnet => "NEXTNET",
+            Self::Stagenet => "STAGENET",
             Self::Mainnet => "MAINNET",
         }
     }
 }
 
-/// Default network is Esme. This will change after mainnet launch
+/// Default network is Stagenet. This will change after mainnet launch
 impl Default for TariNetwork {
     fn default() -> Self {
-        Self::Esmeralda
+        Self::Stagenet
     }
 }
 
@@ -180,9 +180,9 @@ impl TryFrom<&str> for TariNetwork {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
-            "dibbler" => Ok(TariNetwork::Dibbler),
-            "esmeralda" => Ok(TariNetwork::Esmeralda),
             "igor" => Ok(TariNetwork::Igor),
+            "nextnet" => Ok(TariNetwork::Nextnet),
+            "stagenet" => Ok(TariNetwork::Stagenet),
             "mainnet" => Ok(TariNetwork::Mainnet),
             _ => Err(DockerWrapperError::UnsupportedNetwork),
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,8 +31,7 @@ use tari_sdm_assets::configurator::Configurator;
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     let mut configurator = Configurator::init()?;
-    configurator.clean_configuration().await?;
-    configurator.init_configuration().await?;
+    configurator.init_configuration(false).await?;
 
     let workdir = configurator.base_path();
     env::set_current_dir(workdir)?;

--- a/libs/protocol/src/container.rs
+++ b/libs/protocol/src/container.rs
@@ -130,7 +130,7 @@ pub enum TaskStatus {
     Pending,
     Progress(TaskProgress),
     Active,
-    // TODO: Add failed with a reason?
+    Failed(String),
 }
 
 impl TaskStatus {
@@ -145,6 +145,10 @@ impl TaskStatus {
     pub fn is_inactive(&self) -> bool {
         matches!(self, Self::Inactive)
     }
+
+    pub fn is_failed(&self) -> bool {
+        matches!(self, Self::Failed(_))
+    }
 }
 
 impl fmt::Display for TaskStatus {
@@ -154,6 +158,7 @@ impl fmt::Display for TaskStatus {
             Self::Pending => write!(f, "Pending"),
             Self::Progress(value) => write!(f, "Progress({} - {}%)", value.stage, value.pct),
             Self::Active => write!(f, "Active"),
+            Self::Failed(reason) => write!(f, "Failed. Reason: {}", reason),
         }
     }
 }

--- a/libs/protocol/src/settings.rs
+++ b/libs/protocol/src/settings.rs
@@ -95,7 +95,7 @@ impl MmProxyConfig {
 pub struct LaunchpadSettings {
     /// The directory to use for config, id files and logs
     pub data_directory: PathBuf,
-    /// The Tari network to use. Default = esmeralda
+    /// The Tari network to use. Default = stagenet
     pub tari_network: TariNetwork,
     /// The tor control password to share among containers.
     pub tor_control_password: String,
@@ -155,9 +155,8 @@ pub struct UnsupportedNetwork(String);
 /// Supported networks for the launchpad
 #[derive(Serialize, Debug, Deserialize, Clone, Copy)]
 pub enum TariNetwork {
-    Dibbler,
-    Esmeralda,
     Igor,
+    Nextnet,
     Stagenet,
     Mainnet,
 }
@@ -165,9 +164,8 @@ pub enum TariNetwork {
 impl TariNetwork {
     pub fn lower_case(self) -> &'static str {
         match self {
-            Self::Dibbler => "dibbler",
-            Self::Esmeralda => "esmeralda",
             Self::Igor => "igor",
+            Self::Nextnet => "nextnet",
             Self::Stagenet => "stagenet",
             Self::Mainnet => "mainnet",
         }
@@ -175,9 +173,8 @@ impl TariNetwork {
 
     pub fn upper_case(self) -> &'static str {
         match self {
-            Self::Dibbler => "DIBBLER",
-            Self::Esmeralda => "ESMERALDA",
             Self::Igor => "IGOR",
+            Self::Nextnet => "NEXTNET",
             Self::Stagenet => "STAGENET",
             Self::Mainnet => "MAINNET",
         }
@@ -196,9 +193,8 @@ impl TryFrom<&str> for TariNetwork {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
-            "dibbler" => Ok(TariNetwork::Dibbler),
-            "esmeralda" => Ok(TariNetwork::Esmeralda),
             "igor" => Ok(TariNetwork::Igor),
+            "nextnet" => Ok(TariNetwork::Nextnet),
             "mainnet" => Ok(TariNetwork::Mainnet),
             other => Err(UnsupportedNetwork(other.to_owned())),
         }

--- a/libs/sdm-launchpad/src/bus.rs
+++ b/libs/sdm-launchpad/src/bus.rs
@@ -78,7 +78,7 @@ impl LaunchpadWorker {
         in_rx: mpsc::UnboundedReceiver<Action>,
         out_tx: mpsc::UnboundedSender<Reaction>,
     ) -> Result<(), Error> {
-        let mut scope = SdmScope::connect("esmeralda")?;
+        let mut scope = SdmScope::connect("stagenet")?;
         scope.add_network(networks::LocalNet::default())?;
         scope.add_volume(volumes::SharedVolume::default())?;
         scope.add_volume(volumes::SharedGrafanaVolume::default())?;
@@ -125,7 +125,7 @@ impl LaunchpadWorker {
     async fn load_configuration(&mut self) -> Result<(), Error> {
         let mut configurator = Configurator::init()?;
         let data_directory = configurator.base_path().clone();
-        configurator.init_configuration().await?;
+        configurator.init_configuration(false).await?;
         let wallet_config = WalletConfig {
             password: "123".to_string(),
         };

--- a/libs/sdm-launchpad/src/resources/images/l2_base_node.rs
+++ b/libs/sdm-launchpad/src/resources/images/l2_base_node.rs
@@ -77,11 +77,11 @@ impl ManagedContainer for TariBaseNode {
     }
 
     fn image_name(&self) -> &str {
-        "tari_base_node"
+        "minotari_node"
     }
 
     fn tag(&self) -> &str {
-        "v0.49.2_20230628_e0e4ebc"
+        "0.52"
     }
 
     fn reconfigure(&mut self, config: Option<&LaunchpadConfig>) -> Option<bool> {
@@ -136,6 +136,7 @@ impl ManagedContainer for TariBaseNode {
     }
 }
 
+/// A helper struct to track the progress of the initial block download.
 struct Checker {
     progress: SyncProgress,
     identity_sent: bool,
@@ -155,6 +156,10 @@ impl Checker {
 
 #[async_trait]
 impl ContainerChecker<LaunchpadProtocol> for Checker {
+    /// The interval hook in the base node checker is used to query the base node via gRPC for the current sync
+    /// progress. The progress is then reported to the SDM via the `CheckerEvent::Progress` event.
+    /// The task is reported as complete (`READY`) once the `sync_state` value from the `get_sync_progress` RPC call
+    /// is `Done`.
     async fn on_interval(&mut self, ctx: &mut CheckerContext<LaunchpadProtocol>) -> Result<(), Error> {
         if self.ready {
             return Ok(());

--- a/libs/sdm-launchpad/src/resources/images/l2_wallet.rs
+++ b/libs/sdm-launchpad/src/resources/images/l2_wallet.rs
@@ -85,11 +85,11 @@ impl ManagedContainer for TariWallet {
     }
 
     fn image_name(&self) -> &str {
-        "tari_wallet"
+        "minotari_console_wallet"
     }
 
     fn tag(&self) -> &str {
-        "v0.49.2_20230628_e0e4ebc"
+        "0.52"
     }
 
     fn reconfigure(&mut self, config: Option<&LaunchpadConfig>) -> Option<bool> {

--- a/libs/sdm-launchpad/src/resources/images/l3_miner.rs
+++ b/libs/sdm-launchpad/src/resources/images/l3_miner.rs
@@ -57,11 +57,11 @@ impl ManagedContainer for TariSha3Miner {
     }
 
     fn image_name(&self) -> &str {
-        "tari_sha3_miner"
+        "minotari_sha3_miner"
     }
 
     fn tag(&self) -> &str {
-        "v0.49.2_20230628_e0e4ebc"
+        "0.52"
     }
 
     fn reconfigure(&mut self, config: Option<&LaunchpadConfig>) -> Option<bool> {

--- a/libs/sdm-launchpad/src/resources/images/l5_mmproxy.rs
+++ b/libs/sdm-launchpad/src/resources/images/l5_mmproxy.rs
@@ -59,11 +59,11 @@ impl ManagedContainer for MmProxy {
     }
 
     fn image_name(&self) -> &str {
-        "tari_mm_proxy"
+        "minotari_merge_mining_proxy"
     }
 
     fn tag(&self) -> &str {
-        "v0.49.2_20230628_e0e4ebc"
+        "0.52"
     }
 
     fn reconfigure(&mut self, config: Option<&LaunchpadConfig>) -> Option<bool> {

--- a/libs/sdm-launchpad/src/resources/images/mod.rs
+++ b/libs/sdm-launchpad/src/resources/images/mod.rs
@@ -44,7 +44,7 @@ pub use l8_grafana::Grafana;
 pub use l8_loki::Loki;
 pub use l8_promtail::Promtail;
 
-static DEFAULT_REGISTRY: &str = "quay.io/tarilabs";
+static DEFAULT_REGISTRY: &str = "ghcr.io/tari-project";
 static GRAFANA_REGISTRY: &str = "grafana";
 
 static GENERAL_VOLUME: &str = "/var/tari";

--- a/libs/sdm/src/image/checker.rs
+++ b/libs/sdm/src/image/checker.rs
@@ -68,6 +68,11 @@ impl<P: ManagedProtocol> CheckerContext<P> {
     }
 }
 
+/// Polls a container for the logs and stats, and executes the related hooks for the event. If no events are
+/// received for 1 second, the `on_interval` hook is called. The default implementation of all of the hooks do nothing.
+///
+/// In each of the hooks, a mutable reference to a `CheckerContext` is provided, which can be used to access / update
+/// the log and stats history, and update the progress of a task.
 #[async_trait]
 pub trait ContainerChecker<P: ManagedProtocol>: Send {
     async fn entrypoint(mut self: Box<Self>, mut ctx: CheckerContext<P>) {

--- a/libs/sdm/src/image/mod.rs
+++ b/libs/sdm/src/image/mod.rs
@@ -32,6 +32,7 @@ pub(crate) use task::ImageTask;
 
 use crate::config::ManagedProtocol;
 
+/// A container that can be managed by SDM.
 pub trait ManagedContainer: fmt::Debug + Send + 'static {
     type Protocol: ManagedProtocol;
 

--- a/libs/sdm/src/image/task/docker.rs
+++ b/libs/sdm/src/image/task/docker.rs
@@ -363,8 +363,12 @@ struct ProgressConv;
 
 impl Converter<CreateImageInfo, Event> for ProgressConv {
     fn convert(&self, res: Result<CreateImageInfo, Error>) -> Option<Event> {
-        log::debug!("Create Image Info: {:?}", res);
-        let info = res.ok()?;
+        if let Err(err) = res {
+            log::error!("Error while pulling image: {}", err);
+            return Some(Event::PullingFailed(err.to_string()));
+        }
+        let info = res.unwrap();
+        log::debug!("Created Image Info: {:?}", info);
         let details = info.progress_detail?;
         let current = details.current? * 100;
         let total = details.total?;

--- a/libs/sdm/src/image/task/mod.rs
+++ b/libs/sdm/src/image/task/mod.rs
@@ -120,6 +120,7 @@ pub enum Status {
     CleanDangling,
     WaitContainerKilled,
     WaitContainerRemoved,
+    CannotStart,
 
     CreateContainer,
     WaitContainerCreated,
@@ -161,6 +162,7 @@ pub enum ContainerState {
 pub enum Event {
     Destroyed,
     PullingProgress(TaskProgress),
+    PullingFailed(String),
     Created,
     Started,
     Killed,

--- a/libs/sdm/src/status.rs
+++ b/libs/sdm/src/status.rs
@@ -77,7 +77,7 @@ impl<S: TaskStatusChecker> SdmStatus<S> {
     }
 
     pub fn set(&mut self, status: S) {
-        log::debug!("Set the new status !{}::status={:?}", self.name, self.status);
+        log::debug!("Set the new status for [{}]={:?}", self.name, self.status);
         self.status = status;
         self.has_work = true;
         self.fallback = None;

--- a/libs/sdm/src/task.rs
+++ b/libs/sdm/src/task.rs
@@ -319,7 +319,7 @@ where TaskContext<R>: RunnableContext<R>
 
     fn broadcast(&mut self, event: ControlEvent<R::Protocol>) {
         if let Err(err) = self.requests_sender.send(event) {
-            log::error!("Can't brodcast event: {:?}", err);
+            log::error!("Can't broadcast event: {:?}", err);
         }
     }
 
@@ -352,7 +352,7 @@ where TaskContext<R>: RunnableContext<R>
     }
 
     fn check_dependencies(&mut self) {
-        // If the set is empty `all` returs `true`.
+        // If the set is empty `all` returns `true`.
         self.context.dependencies_ready = self.dependencies.values().all(|ready| *ready);
     }
 

--- a/libs/sim-launchpad/src/simulator.rs
+++ b/libs/sim-launchpad/src/simulator.rs
@@ -228,6 +228,7 @@ impl Simulator {
             (_, false) => {
                 new_status = Some(TaskStatus::Inactive);
             },
+            (TaskStatus::Failed(_), _) => {}
         }
         if let Some(status) = new_status {
             let delta = TaskDelta::UpdateStatus(status);

--- a/libs/sim-launchpad/src/simulator.rs
+++ b/libs/sim-launchpad/src/simulator.rs
@@ -228,7 +228,7 @@ impl Simulator {
             (_, false) => {
                 new_status = Some(TaskStatus::Inactive);
             },
-            (TaskStatus::Failed(_), _) => {}
+            (TaskStatus::Failed(_), _) => {},
         }
         if let Some(status) = new_status {
             let delta = TaskDelta::UpdateStatus(status);


### PR DESCRIPTION
As part of updating launchpad to use stage- and main-net, we need to
update the containers used, as well as bring configuratino up-to-date.

This PR is primarily focussed on updating the containers:
- use Github package repos instead of quay.io
- use stagenet instead of esme as default
- use ver 0.52 (this must change to stagenet-latest soon, but tags
  aren't up yet)

docs:

- Parsing the code, adding some helpful docs as I go.

behaviour changes:
- Config files are *not* deleted on startup. This is important. Users should be able to tweak settings between launches and have them persist.