### PR TITLE
chore: update checkout github action

### DIFF
--- a/.github/workflows/reusable-ci-jobs.yml
+++ b/.github/workflows/reusable-ci-jobs.yml
@@ -100,7 +100,7 @@
           runs-on: ubuntu-20.04
           steps:
               - name: checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
               - name: toolchain
                 uses: actions-rs/toolchain@v1
                 with:
@@ -150,7 +150,7 @@
         runs-on: ubuntu-20.04
         steps:
           - name: checkout
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
           - name: setup node
             uses: actions/setup-node@v4
             with:

--- a/.github/workflows/reusable-licenses.yml
+++ b/.github/workflows/reusable-licenses.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: install ripgrep
         run: |
           wget https://github.com/BurntSushi/ripgrep/releases/download/13.0.0/ripgrep_13.0.0_amd64.deb

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: toolchain
         uses: actions-rs/toolchain@v1
       - name: setup node


### PR DESCRIPTION
Some actions were using checkout@v2, which could possibly be why some workflows are failing due to conflicting permissions when installing Node

Description
---

Motivation and Context
---

How Has This Been Tested?
---

