### PR TITLE
chore: deduplicate ci tests

### DIFF
--- a/.github/workflows/launchpad_v2.yml
+++ b/.github/workflows/launchpad_v2.yml
@@ -1,7 +1,6 @@
 name: Launchpad v2 CI
 
 on:
-  push:
   pull_request:
     types:
       - opened


### PR DESCRIPTION
No need to run on push when we're already running on pull requests


