### PR TITLE
fix: don't install node.js when doing cargo clippy

### DIFF
--- a/.github/workflows/reusable-ci-jobs.yml
+++ b/.github/workflows/reusable-ci-jobs.yml
@@ -108,10 +108,6 @@
                     profile: minimal
               - name: Cache rust dependencies
                 uses: Swatinem/rust-cache@v1
-              - name: setup node
-                uses: actions/setup-node@v4
-                with:
-                    node-version: "20"
               - name: ubuntu dependencies
                 if: ${{ inputs.build-tari }}
                 run: |


### PR DESCRIPTION
Node.js isn't required when running cargo clippy, and it often causes a deadlock / race for write permissions, failing the CI


