### PR TITLE
ci(fix): bump 3rd party releases

### DIFF
--- a/docker_rig/monerod.Dockerfile
+++ b/docker_rig/monerod.Dockerfile
@@ -8,33 +8,38 @@
 # Binary build
 
 # https://github.com/monero-project/monero/releases
-ARG MONERO_VERSION=0.18.2.2
+ARG MONERO_VERSION=0.18.3.1
+
+# https://hub.docker.com/r/bitnami/minideb
+ARG OS_BASE=bookworm
 
 # Declare stage using linux/amd64 base image
-FROM --platform=linux/amd64 bitnami/minideb:bullseye AS build-stage-amd64
+FROM --platform=linux/amd64 bitnami/minideb:${OS_BASE} AS build-stage-amd64
 
 # Platform Args
 ARG MONERO_ARCH=x64
 ARG MONERO_TAR=x86_64
 
 # https://github.com/monero-project/monero/releases
-ARG MONERO_AMD64_SHA256=186800de18f67cca8475ce392168aabeb5709a8f8058b0f7919d7c693786d56b
+# monero-linux-x64
+ARG MONERO_AMD64_SHA256=23af572fdfe3459b9ab97e2e9aa7e3c11021c955d6064b801a27d7e8c21ae09d
 ARG MONERO_VERSION
 
 # Declare stage using linux/arm64 base image
-FROM --platform=linux/arm64 bitnami/minideb:bullseye AS build-stage-arm64
+FROM --platform=linux/arm64 bitnami/minideb:${OS_BASE} AS build-stage-arm64
 
 # Platform Args
 ARG MONERO_ARCH=armv8
 ARG MONERO_TAR=aarch64
 
 # https://github.com/monero-project/monero/releases
-ARG MONERO_ARM64_SHA256=f3867f2865cb98ab1d18f30adfd9168f397bd07bf7c36550dfe3a2a11fc789ba
+# monero-linux-armv8
+ARG MONERO_ARM64_SHA256=445032e88dc07e51ac5fff7034752be530d1c4117d8d605100017bcd87c7b21f
 ARG MONERO_VERSION
 
 # Declare TARGETARCH to make it available
 ARG TARGETARCH
-# Select final stage based on TARGETARCH ARG
+# Select download stage based on TARGETARCH ARG
 FROM build-stage-${TARGETARCH} as build-stage-download
 
 ARG BUILDPLATFORM
@@ -63,10 +68,12 @@ RUN curl https://dlsrc.getmonero.org/cli/monero-linux-$MONERO_ARCH-v$MONERO_VERS
   cp ./monero-$MONERO_TAR-linux-gnu-v$MONERO_VERSION/monerod . && \
   rm -r monero-*
 
-FROM bitnami/minideb:bullseye AS runtime-stage
+
+FROM bitnami/minideb:${OS_BASE} AS runtime-stage
 
 # Bring over the Args from platform selection
 ARG BUILDPLATFORM
+ARG OS_BASE
 
 ARG MONERO_VERSION
 ARG VERSION=1.0.1

--- a/docker_rig/tarilabs.Dockerfile
+++ b/docker_rig/tarilabs.Dockerfile
@@ -1,10 +1,11 @@
 # syntax = docker/dockerfile:1.3
 
 # https://hub.docker.com/_/rust
-ARG RUST_VERSION=1.71
+ARG RUST_VERSION=1.74
+ARG OS_BASE=bookworm
 
 # rust source compile with cross platform build support
-FROM --platform=$BUILDPLATFORM rust:$RUST_VERSION-bullseye as builder
+FROM --platform=$BUILDPLATFORM rust:$RUST_VERSION-${OS_BASE} as builder
 
 # Declare to make available
 ARG BUILDPLATFORM
@@ -18,6 +19,7 @@ ARG TARGETVARIANT
 ARG RUST_TOOLCHAIN
 ARG RUST_TARGET
 ARG RUST_VERSION
+ARG OS_BASE
 
 # Disable Prompt During Packages Installation
 ARG DEBIAN_FRONTEND=noninteractive
@@ -99,13 +101,14 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "${TARGETARCH}" ] ; 
     cp -v /tari/target/${BUILD_TARGET}release/${APP_EXEC} /tari/${APP_EXEC}
 
 # Create runtime base minimal image for the target platform executables
-FROM --platform=$TARGETPLATFORM bitnami/minideb:bullseye as runtime
+FROM --platform=$TARGETPLATFORM bitnami/minideb:${OS_BASE} as runtime
 
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
 ARG RUST_VERSION
+ARG OS_BASE
 
 ARG VERSION
 

--- a/docker_rig/tor.Dockerfile
+++ b/docker_rig/tor.Dockerfile
@@ -9,7 +9,7 @@ ARG BUILDPLATFORM
 ARG VERSION=1.0.1
 
 # https://pkgs.alpinelinux.org/packages?name=tor&branch=v3.18&repo=community&arch=&maintainer=
-ARG TOR_VERSION=0.4.7.13-r2
+ARG TOR_VERSION=0.4.8.9-r0
 
 # Install tor with a minimum version
 RUN apk add --no-cache grep curl tor>$TOR_VERSION

--- a/docker_rig/xmrig.Dockerfile
+++ b/docker_rig/xmrig.Dockerfile
@@ -8,7 +8,7 @@ ARG ALPINE_VERSION
 ARG BUILDPLATFORM
 
 # https://github.com/xmrig/xmrig/releases
-ARG XMRIG_VERSION="v6.20.0"
+ARG XMRIG_VERSION="v6.21.0"
 
 RUN apk add \
     git \


### PR DESCRIPTION
Description
Bump tor, xmrig and monerod releases. Add env override over base OS image, switching from bullseye to bookworm.

Motivation and Context
Use the latest code.

How Has This Been Tested?
Built and pushed locally. No run tests yet.

