### PR TITLE
feat: randomise tor control password

### DIFF
--- a/libs/sdm-launchpad/src/bus.rs
+++ b/libs/sdm-launchpad/src/bus.rs
@@ -30,7 +30,7 @@ use tari_launchpad_protocol::{
     launchpad::{Action, LaunchpadAction, LaunchpadDelta, LaunchpadState, Reaction},
     settings::PersistentSettings,
 };
-use tari_sdm::{ids::ManagedTask, Report, ReportEnvelope, SdmScope};
+use tari_sdm::{ids::ManagedTask, utils::create_password, Report, ReportEnvelope, SdmScope};
 use tari_sdm_assets::configurator::Configurator;
 use tokio::{select, sync::mpsc};
 
@@ -152,7 +152,7 @@ impl LaunchpadWorker {
         let config = LaunchpadSettings {
             data_directory,
             with_monitoring: true,
-            tor_control_password: "tari".to_string(), // create_password(16).into(),
+            tor_control_password: create_password(16).into(),
             saved_settings,
             ..Default::default()
         };

--- a/libs/sdm-launchpad/src/resources/config.rs
+++ b/libs/sdm-launchpad/src/resources/config.rs
@@ -130,9 +130,11 @@ impl ConnectionSettings {
 }
 
 impl ConnectionSettings {
-    pub fn add_tor(&self, envs: &mut Envs) {
+    pub fn add_tor(&self, module: &str, envs: &mut Envs) {
         let value = format!("password={}", self.tor_password.deref());
-        envs.set("TARI_BASE_NODE__P2P__TRANSPORT__TOR__CONTROL_AUTH", value);
+        let module = module.to_uppercase();
+        let var_name = format!("TARI_{module}__P2P__TRANSPORT__TOR__CONTROL_AUTH");
+        envs.set(&var_name, value);
     }
 
     pub fn add_common(&self, envs: &mut Envs) {

--- a/libs/sdm-launchpad/src/resources/images/l2_base_node.rs
+++ b/libs/sdm-launchpad/src/resources/images/l2_base_node.rs
@@ -105,7 +105,7 @@ impl ManagedContainer for TariBaseNode {
     fn envs(&self, envs: &mut Envs) {
         if let Some(settings) = self.settings.as_ref() {
             settings.add_common(envs);
-            settings.add_tor(envs);
+            settings.add_tor("BASE_NODE", envs);
             // envs.set("WAIT_FOR_TOR", 10);
             envs.set(
                 "TARI_BASE_NODE__DATA_DIR",

--- a/libs/sdm-launchpad/src/resources/images/l2_wallet.rs
+++ b/libs/sdm-launchpad/src/resources/images/l2_wallet.rs
@@ -133,7 +133,7 @@ impl ManagedContainer for TariWallet {
     fn envs(&self, envs: &mut Envs) {
         if let Some(settings) = self.settings.as_ref() {
             settings.add_common(envs);
-            settings.add_tor(envs);
+            settings.add_tor("WALLET", envs);
             envs.set("WAIT_FOR_TOR", 0);
             envs.set(
                 "TARI_BASE_NODE__DATA_DIR",

--- a/libs/sdm-launchpad/src/resources/images/l3_miner.rs
+++ b/libs/sdm-launchpad/src/resources/images/l3_miner.rs
@@ -77,7 +77,6 @@ impl ManagedContainer for TariSha3Miner {
     fn envs(&self, envs: &mut Envs) {
         if let Some(settings) = self.settings.as_ref() {
             settings.add_common(envs);
-            settings.add_tor(envs);
             envs.set("TARI_MINER__NUM_MINING_THREADS", 8); // TODO: Get config num
             envs.set("TARI_MINER__MINE_ON_TIP_ONLY", 1);
             envs.set(

--- a/libs/sdm-launchpad/src/resources/images/l5_mmproxy.rs
+++ b/libs/sdm-launchpad/src/resources/images/l5_mmproxy.rs
@@ -97,7 +97,6 @@ impl ManagedContainer for MmProxy {
     fn envs(&self, envs: &mut Envs) {
         if let Some(settings) = self.settings.as_ref() {
             settings.add_common(envs);
-            settings.add_tor(envs);
         }
         envs.set("APP_NAME", "mm_proxy");
         envs.set("APP_EXEC", "minotari_merge_mining_proxy");


### PR DESCRIPTION
The tor control port password can be made ephemeral and random when the tor container is started. This password can be supplied to other containers so that they can access Tor.

This prevents actors that have access to the docker daemon from using the Tor control port -- assuming they're unable to `exec` or `attach` to any running container in order to access the environment.


