### PR TITLE
fix: startup issues

### DIFF
--- a/libs/sdm-assets/assets/config.toml
+++ b/libs/sdm-assets/assets/config.toml
@@ -28,8 +28,8 @@ identity_file = "/var/tari/base_node/config/nextnet/tari_base_node_id.json"
 grpc_server_deny_methods = []
 
 [base_node.p2p]
-#auxiliary_tcp_listener_address = "/dns4/base_node/tcp/18189"
-auxiliary_tcp_listener_address = "/ip4/0.0.0.0/tcp/18189"
+auxiliary_tcp_listener_address = "/dns4/base_node/tcp/18189"
+#auxiliary_tcp_listener_address = "/ip4/0.0.0.0/tcp/18189"
 user_agent = "Launchpad base node"
 
 [base_node.p2p.transport]
@@ -92,7 +92,7 @@ socks_address_override = "/dns4/tor/tcp/9050"
 control_address = "/dns4/tor/tcp/9051"
 # When these peer addresses are encountered when dialing another peer, the tor proxy is bypassed and the connection is
 # made directly over TCP. /ip4, /ip6, /dns, /dns4 and /dns6 are supported. (e.g. ["/dns4/my-foo-base-node/tcp/9998"])
-proxy_bypass_addresses = ["/dns4/wallet/tcp/18188"]
+proxy_bypass_addresses = ["/dns4/base_node/tcp/18189", "/ip4/127.0.0.1/tcp/18189", "/dns4/localhost/tcp/18189"]
 proxy_bypass_for_outbound_tcp = true
 
 [wallet.p2p.transport.tcp]

--- a/libs/sdm-launchpad/src/resources/images/l2_base_node.rs
+++ b/libs/sdm-launchpad/src/resources/images/l2_base_node.rs
@@ -98,7 +98,10 @@ impl ManagedContainer for TariBaseNode {
 
     fn args(&self, args: &mut Args) {
         args.set("--log-config", "/var/tari/config/log4rs.yml");
-        // args.flag("-n");
+        // An id file is only generated if `--init` or `-n` is specified. But the node exits immediately if `--init` is
+        // specified. So for now, we must run in non-interactive mode to have launchpad work.
+        // args.flag("--init");
+        args.flag("--n");
         args.set("--watch", "status");
     }
 
@@ -106,7 +109,6 @@ impl ManagedContainer for TariBaseNode {
         if let Some(settings) = self.settings.as_ref() {
             settings.add_common(envs);
             settings.add_tor("BASE_NODE", envs);
-            // envs.set("WAIT_FOR_TOR", 10);
             envs.set(
                 "TARI_BASE_NODE__DATA_DIR",
                 format!("/blockchain/{}", settings.tari_network.lower_case()),


### PR DESCRIPTION
When starting from a completely clean build, the node doesn't create the id.

This requires running in non-interactive mode for now.

There's also a bug in the comms layer where the wallet's peer db must be deleted in order to get the wallet to connect internally to get the wallet to reconnect via TCP on next launch.


