### PR TITLE
feat: fix startup bugs

### DIFF
--- a/cli/src/component/normal/wallet/balance.rs
+++ b/cli/src/component/normal/wallet/balance.rs
@@ -116,13 +116,22 @@ impl<B: Backend> Component<B> for BalanceWidget {
         let table = Table::new(rows)
             .widths(&[Constraint::Percentage(40), Constraint::Percentage(60)])
             .column_spacing(2);
-
-        let help = Paragraph::new(Text::from(
-            "\
+        let interactive = state
+            .state
+            .config
+            .settings
+            .as_ref()
+            .and_then(|lps| lps.saved_settings.wallet.as_ref())
+            .map(|w| w.interactive)
+            .unwrap_or_default();
+        if interactive && state.state.config.session.is_wallet_active() {
+            let help = Paragraph::new(Text::from(
+                "\
                 To access the full-featured console\nwallet, open a new terminal and run\n\ndocker attach \
-             stagenet_minotari_console_wallet\n\n",
-        ));
-        f.render_widget(help, h_chunks[1]);
+                 stagenet_minotari_console_wallet\n\n",
+            ));
+            f.render_widget(help, h_chunks[1]);
+        }
         f.render_widget(table, v_chunks[0]);
     }
 }

--- a/libs/protocol/src/settings.rs
+++ b/libs/protocol/src/settings.rs
@@ -33,12 +33,29 @@ http://xmr-lux.boldsuck.org:38081,\
 http://singapore.node.xmr.pm:38081";
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct BaseNodeConfig {}
+pub struct BaseNodeConfig {
+    /// Should node be started in interactive mode.
+    pub interactive: bool,
+}
 
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WalletConfig {
     /// The password to de/en-crypt the wallet database
     pub password: String,
+    /// Should the peer DB be deleted before starting up. Issue: https://github.com/tari-project/tari/issues/5998
+    pub clear_peer_db: bool,
+    /// Should wallet be started in interactive mode.
+    pub interactive: bool,
+}
+
+impl Default for WalletConfig {
+    fn default() -> Self {
+        WalletConfig {
+            password: String::new(),
+            clear_peer_db: true,
+            interactive: false,
+        }
+    }
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]

--- a/libs/sdm-assets/assets/settings.toml
+++ b/libs/sdm-assets/assets/settings.toml
@@ -1,6 +1,9 @@
 # Local settings for launchpad
 tari_network = "Stagenet"
 
+[base_node]
+interactive = false
+
 [sha3_miner]
 num_mining_threads = 1
 
@@ -17,3 +20,5 @@ monero_mining_address = "5AJ8FwQge4UjT9Gbj4zn7yYcnpVQzzkqr636pKto59jQcu85CFsuYVe
 
 [wallet]
 password = "tari"
+interactive = false
+clear_peer_db = true


### PR DESCRIPTION
1. Wallet

* There are 2 extra settings in the wallet config. `clear_peer_db`, clears the peer database when configuring the wallet.
This should be true for at least the first run or until https://github.com/tari-project/tari/issues/5998 is fixed.
* `interactive` must be false for the first run, and can be set to true after that.
* We only display the instructions for attaching to the docker wallet instance if interactive is true, and the wallet is active.

2. Base node

Similarly to the wallet, there's an `interactive` setting for the base node now that must be false on the first run.

Note: A future PR should make these editable in the UI.

