### PR TITLE
fix: don't spam key events

### DIFF
--- a/cli/src/dashboard.rs
+++ b/cli/src/dashboard.rs
@@ -197,6 +197,10 @@ impl Do<TermEvent> for Dashboard {
         match event {
             TermEvent::Event(event) => {
                 if let Event::Key(key) = event {
+                    // Don't process key down events, only key up, otherwise repeat rate is too high.
+                    if key.kind != crossterm::event::KeyEventKind::Release {
+                        return Ok(());
+                    }
                     let state = self.state.as_mut().ok_or_else(|| DashboardError::State)?;
                     self.main_view.on_event(key.into(), state);
                     let changed = state.process_events();


### PR DESCRIPTION
Description
---
Only propagate events on KeyRelease. 

Motivation and Context
---
Previously, all keyboard events, Down, Repeat, Up would trigger this event. We only need the first down or release. Doing actions on release might be a bit strange though, so I'll also try with KeyDown. I'm not super familiar with cross term though

How Has This Been Tested?
---
Set your keyboard repeat rate to high to test the code before this change, then try it with this change

