### PR TITLE
fix: macos terminal issue

### DIFF
--- a/cli/src/dashboard.rs
+++ b/cli/src/dashboard.rs
@@ -198,9 +198,11 @@ impl Do<TermEvent> for Dashboard {
             TermEvent::Event(event) => {
                 if let Event::Key(key) = event {
                     // Don't process key down events, only key up, otherwise repeat rate is too high.
+                    #[cfg(windows)]
                     if key.kind != crossterm::event::KeyEventKind::Release {
                         return Ok(());
                     }
+
                     let state = self.state.as_mut().ok_or_else(|| DashboardError::State)?;
                     self.main_view.on_event(key.into(), state);
                     let changed = state.process_events();


### PR DESCRIPTION
Description
---
MacOS wasn't receiving any propagated events due to this windows fix. The windows fix stops from receiving too many spammed events and is a required fix. MacOS/Linux doesn't seem to get hit with this level of propagation and this fix actually prevents any key events from reaching the app.

Conditionally compile the fix for windows only.

Motivation and Context
---
Without the fix, things be broke.

How Has This Been Tested?
---
Manually
