### PR TITLE
chore: version bump to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5363,7 +5363,7 @@ dependencies = [
 
 [[package]]
 name = "tari-lp-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_launchpad"
-version = "1.2.0"
+version = "1.3.0"
 description = "A unified user interface for a Tari node, wallet and miner, with a focus on ease-of-use and UX."
 authors = ["The Tari Development Community"]
 license = "BSD-3-Clause"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari-lp-cli"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Description
---
The version with no wallet.