### PR TITLE
chore(ci): add apple arm64 build using macos-14 runner

### DIFF
--- a/.github/workflows/build_cli.json
+++ b/.github/workflows/build_cli.json
@@ -31,11 +31,11 @@
   },
   {
     "name": "macos-arm64",
-    "runs-on": "macos-13",
+    "runs-on": "macos-14",
     "rust": "stable",
     "target": "aarch64-apple-darwin",
     "cross": false,
-    "build_enabled": false
+    "build_enabled": true
   },
   {
     "name": "windows-x64",


### PR DESCRIPTION
Description
Add Apple arm64 (M1) build using the GitHub runner macos-14, which are M1 hardware, no need to cross-compile

Motivation and Context
Add Apple arm64 assets

How Has This Been Tested?
Built in local fork

