### PR TITLE
fix: commit missing monero settings

### DIFF
--- a/libs/sdm-assets/assets/settings.toml
+++ b/libs/sdm-assets/assets/settings.toml
@@ -9,11 +9,11 @@ num_mining_threads = 1
 
 [mm_proxy]
 # You can specify multiple monerod instances here, separated by commas
-monerod_url = "http://stagenet.xmr-tw.org:38081, http://stagenet.community.xmr.to:38081, http://monero-stagenet.exan.tech:38081, http://xmr-lux.boldsuck.org:38081, http://singapore.node.xmr.pm:38081"
+monerod_url = "http://xmr.support:18081, http://node1.xmr-tw.org:18081, http://xmr.nthrow.nyc:18081, http://node.xmrig.com:18081, http://monero.exan.tech:18081, http://18.132.124.81:18081"
 monero_username = ""
 monero_password = ""
 monero_use_auth = false
 
 [xmrig]
 # Replace this with your own Monero wallet address
-monero_mining_address = "5AJ8FwQge4UjT9Gbj4zn7yYcnpVQzzkqr636pKto59jQcu85CFsuYVeFgbhUdRpiPjUCkA4sQtWApUzCyTMmSigFG2hDo48"
+monero_mining_address = "888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H"


### PR DESCRIPTION
Description
---
Missed updating these monero settings in the last PR.

Motivation and Context
---
Set to the mainnet community wallet.

How Has This Been Tested?
---
manually
