### PR TITLE
feat: enable docker detect for wsl2

### DIFF
--- a/cli/src/component/widgets/docker_detect.rs
+++ b/cli/src/component/widgets/docker_detect.rs
@@ -27,7 +27,11 @@ use crate::component::{widgets::popup::Popup, Frame};
 
 pub fn is_docker_running() -> bool {
     match std::process::Command::new("docker").arg("version").output() {
-        Ok(output) => output.stderr.is_empty(),
+        Ok(output) => {
+            let is_wsl2_error =
+                String::from_utf8_lossy(&output.stdout).contains("The command 'docker' could not be found");
+            output.stderr.is_empty() && !is_wsl2_error
+        },
         Err(_) => false,
     }
 }
@@ -36,8 +40,8 @@ pub fn display_docker_notice<B: Backend>(f: &mut Frame<B>, title: &str, msg: &st
     let popup_area = Rect {
         x: 4,
         y: 2,
-        width: 50,
-        height: 8,
+        width: 80,
+        height: 10,
     };
     let popup = Popup::default()
         .content(msg)

--- a/cli/src/dashboard.rs
+++ b/cli/src/dashboard.rs
@@ -120,9 +120,9 @@ impl Actor for Dashboard {
             let url = "https://docs.docker.com/engine/install/ubuntu/";
 
             let msg = format!(
-                "\nThe Docker process is not detected.\nIs it installed and running?\n\
-            Download docker at {url}\n\
-            'Ctrl Q' to quit."
+                "\nThe Docker process is not detected.\nIs it installed and running?\n\n\
+            Download docker at {url}\n\n\
+            Press any key to quit."
             );
             if self
                 .terminal


### PR DESCRIPTION
Description
---
Enabled docker detect for WSL2 Ubuntu distributions.

Motivation and Context
---
The Docker version command (`docker --version`) behaves differently on WSL2 Ubuntu distributions compared to bare metal Ubuntu distributions when the `Use the WSL 2 based engine` setting is enabled, as it then uses the same Docker Desktop and engine for both Windows and Ubuntu.

![image](https://github.com/tari-project/tari-launchpad/assets/39146854/7d8d7534-2ae2-4932-8b25-720c1a40219c)

How Has This Been Tested?
---
System-level testing with Windows and WSL2 Ubuntu
