### PR TITLE
feat: interpret all docker states with shutdown

### DIFF
--- a/cli/src/component/main_view.rs
+++ b/cli/src/component/main_view.rs
@@ -73,16 +73,16 @@ impl Input for MainView {
             state.update_state();
 
             // Spawn a new thread to exit the process after 30s if it has not already exited
-            if !is_docker_running() {
-                let _ = disable_raw_mode();
-                std::process::exit(0);
-            } else {
+            if is_docker_running() {
                 std::thread::spawn(|| {
                     std::thread::sleep(std::time::Duration::from_secs(60));
                     log::warn!("The process did not stop cleanly. Terminating it.");
-                    let _ = disable_raw_mode();
+                    let _unused = disable_raw_mode();
                     std::process::exit(0);
                 });
+            } else {
+                let _unused = disable_raw_mode();
+                std::process::exit(0);
             }
         } else if matches!(event, ComponentEvent::StateChanged) {
             self.normal_scene.on_event(event, state);

--- a/cli/src/component/main_view.rs
+++ b/cli/src/component/main_view.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
+use crossterm::terminal::disable_raw_mode;
 use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
@@ -71,8 +72,17 @@ impl Input for MainView {
             state.focus_on(focus::TERMINATION);
             state.update_state();
 
+            // Spawn a new thread to exit the process after 30s if it has not already exited
             if !is_docker_running() {
+                let _ = disable_raw_mode();
                 std::process::exit(0);
+            } else {
+                std::thread::spawn(|| {
+                    std::thread::sleep(std::time::Duration::from_secs(60));
+                    log::warn!("The process did not stop cleanly. Terminating it.");
+                    let _ = disable_raw_mode();
+                    std::process::exit(0);
+                });
             }
         } else if matches!(event, ComponentEvent::StateChanged) {
             self.normal_scene.on_event(event, state);

--- a/cli/src/dashboard.rs
+++ b/cli/src/dashboard.rs
@@ -246,7 +246,9 @@ impl Do<TermEvent> for Dashboard {
                 ctx.do_next(Redraw)?;
             },
             TermEvent::End => {
+                log::debug!("[Shutdown] `TermEvent::End` received");
                 ctx.shutdown();
+                tokio::time::sleep(Duration::from_secs(10)).await;
             },
         }
         Ok(())
@@ -268,7 +270,10 @@ impl Do<Tick> for Dashboard {
             ctx.do_next(Redraw)?;
         }
         if state.is_terminated() {
+            log::debug!("[Shutdown] Containers' state is terminated");
             self.stop_the_app()?;
+            ctx.shutdown();
+            tokio::time::sleep(Duration::from_secs(10)).await;
         }
         Ok(())
     }

--- a/cli/src/dashboard.rs
+++ b/cli/src/dashboard.rs
@@ -246,9 +246,7 @@ impl Do<TermEvent> for Dashboard {
                 ctx.do_next(Redraw)?;
             },
             TermEvent::End => {
-                log::debug!("[Shutdown] `TermEvent::End` received");
                 ctx.shutdown();
-                tokio::time::sleep(Duration::from_secs(10)).await;
             },
         }
         Ok(())
@@ -270,10 +268,8 @@ impl Do<Tick> for Dashboard {
             ctx.do_next(Redraw)?;
         }
         if state.is_terminated() {
-            log::debug!("[Shutdown] Containers' state is terminated");
             self.stop_the_app()?;
             ctx.shutdown();
-            tokio::time::sleep(Duration::from_secs(10)).await;
         }
         Ok(())
     }

--- a/cli/src/supervisor.rs
+++ b/cli/src/supervisor.rs
@@ -23,6 +23,7 @@
 
 use anyhow::Error;
 use async_trait::async_trait;
+use std::time::Duration;
 use tact::{Actor, ActorContext, Address, Do};
 
 use crate::dashboard::{Dashboard, DashboardEvent};
@@ -49,8 +50,10 @@ impl Do<DashboardEvent> for Supervisor {
     async fn handle(&mut self, event: DashboardEvent, ctx: &mut ActorContext<Self>) -> Result<(), Self::Error> {
         match event {
             DashboardEvent::Terminated => {
+                log::debug!("[Shutdown] `DashboardEvent::Terminatedd` received");
                 self.dashboard.take();
                 ctx.shutdown();
+                tokio::time::sleep(Duration::from_secs(10)).await;
             },
         }
         Ok(())

--- a/cli/src/supervisor.rs
+++ b/cli/src/supervisor.rs
@@ -23,7 +23,6 @@
 
 use anyhow::Error;
 use async_trait::async_trait;
-use std::time::Duration;
 use tact::{Actor, ActorContext, Address, Do};
 
 use crate::dashboard::{Dashboard, DashboardEvent};
@@ -50,10 +49,8 @@ impl Do<DashboardEvent> for Supervisor {
     async fn handle(&mut self, event: DashboardEvent, ctx: &mut ActorContext<Self>) -> Result<(), Self::Error> {
         match event {
             DashboardEvent::Terminated => {
-                log::debug!("[Shutdown] `DashboardEvent::Terminatedd` received");
                 self.dashboard.take();
                 ctx.shutdown();
-                tokio::time::sleep(Duration::from_secs(10)).await;
             },
         }
         Ok(())

--- a/libs/sdm/src/image/task/mod.rs
+++ b/libs/sdm/src/image/task/mod.rs
@@ -161,6 +161,9 @@ pub enum ContainerState {
     Removing,
     Exited,
     Dead,
+    ErrorStatusNotDefined,
+    ErrorStateNotDefined,
+    NotFound,
 }
 
 #[derive(Debug)]

--- a/libs/sdm/src/image/task/mod.rs
+++ b/libs/sdm/src/image/task/mod.rs
@@ -153,9 +153,14 @@ impl Default for Status {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ContainerState {
+    Empty,
+    Created,
     Running,
-    NotRunning,
-    NotFound,
+    Paused,
+    Restarting,
+    Removing,
+    Exited,
+    Dead,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Description
---
- Added code to interpret all docker states with shutdown and act accordingly. This is to prevent Docker from going into undefined states with undefined behaviour.
- Improved shutdown, in general, to give time for docker containers to be shutdown properly.
- Improved shutdown when docker is closed manually.

Motivation and Context
---
All docker states were not interpreted and this caused docker containers to be left in undefined states when exiting.

How Has This Been Tested?
---
System-level tests on Windows and Ubuntu-WSL
