### PR TITLE
feat: set pruned mode as default

### DIFF
--- a/docker_rig/config.toml
+++ b/docker_rig/config.toml
@@ -6,8 +6,8 @@ override_from = "stagenet"
 grpc_enabled = true
 
 [base_node.storage]
-# pruning_horizon = 10_080
-# pruning_interval = 50
+pruning_horizon = 1_440 # 2 days
+pruning_interval = 50
 track_reorgs = true
 
 


### PR DESCRIPTION
Description
---
Set the pruned mode as the default,

Motivation and Context
---
Pruned mode should be the default for LP as users should be up and running as quickly as possible, either running it for the first time or starting it up after being absent for a long time. Recently horizon sync has been fully implemented after the Merkle tree upgrade to SMT and is now working properly. 

How Has This Been Tested?
---
System-level testing
