### PR TITLE
chore: version bump to v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "tari-lp-cli"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_launchpad"
-version = "1.5.0"
+version = "1.6.0"
 description = "A unified user interface for a Tari node, wallet and miner, with a focus on ease-of-use and UX."
 authors = ["The Tari Development Community"]
 license = "BSD-3-Clause"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari-lp-cli"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Description
---
version bump to v1.6.0

Motivation and Context
---
bumping version to v1.6.0

How Has This Been Tested?
---
I looked at the number that was 1.5.0 and now it's 1.6.0.
