### PR TITLE
feat: remove spin lock

### DIFF
--- a/cli/src/component/main_view.rs
+++ b/cli/src/component/main_view.rs
@@ -72,7 +72,7 @@ impl Input for MainView {
             state.focus_on(focus::TERMINATION);
             state.update_state();
 
-            // Spawn a new thread to exit the process after 30s if it has not already exited
+            // Spawn a new thread to exit the process as a failsafe if the process does not close normally
             if is_docker_running() {
                 std::thread::spawn(|| {
                     std::thread::sleep(std::time::Duration::from_secs(60));

--- a/libs/sdm/src/image/task/update.rs
+++ b/libs/sdm/src/image/task/update.rs
@@ -47,6 +47,7 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn do_initial_state(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Image] `do_initial_state` {}", self.inner.image_name);
         self.update_task_status(TaskStatus::Inactive)?;
 
         log::debug!("Checking image {} ...", self.inner.image_name);
@@ -77,6 +78,7 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn do_pulling(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Image] `do_pulling` {}", self.inner.image_name);
         if self.image_exists().await {
             // Just loaded, container can't be exist
             self.status.set(Status::Idle);
@@ -89,6 +91,7 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     /// manually in docker. If the container is still running, we'll try and kill it first, otherwise we'll just
     /// remove it.
     async fn do_clean_dangling(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Image] `do_clean_dangling` {}", self.inner.image_name);
         log::debug!(
             "[Clean dangling] Checking for dangling instance of container {} ...",
             self.inner.container_name
@@ -147,6 +150,10 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn do_wait_container_killed(&mut self) -> Result<(), Error> {
+        log::trace!(
+            "[Update event: Image] `do_wait_container_killed` {}",
+            self.inner.image_name
+        );
         let state = self.container_state().await;
         log::debug!(
             "[Clean dangling] `do_wait_container_killed` for container `{}` enter state: `{:?}`",
@@ -187,6 +194,10 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn do_wait_container_removed(&mut self) -> Result<(), Error> {
+        log::trace!(
+            "[Update event: Image] `do_wait_container_removed` {}",
+            self.inner.image_name
+        );
         let state = self.container_state().await;
         log::debug!(
             "[Clean dangling] `do_wait_container_removed` for container `{}`, enter state: `{:?}`",
@@ -227,10 +238,12 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn abort(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Image] `abort` {}", self.inner.image_name);
         Ok(())
     }
 
     async fn do_idle(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Image] `do_idle` {}", self.inner.image_name);
         if self.force_pull {
             self.force_pull = false;
             self.status.set(Status::DropImage);
@@ -249,6 +262,7 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn do_create_container(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Image] `do_create_container` {}", self.inner.image_name);
         log::debug!("Trying to create container {} ...", self.inner.container_name);
         // TODO: Process the result as well
         self.try_create_container().await?;
@@ -257,11 +271,16 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn do_wait_container_created(&mut self) -> Result<(), Error> {
+        log::trace!(
+            "[Update event: Image] `do_wait_container_created` {}",
+            self.inner.image_name
+        );
         // TODO: Check timeout
         Ok(())
     }
 
     async fn do_start_container(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Image] `do_start_container` {}", self.inner.image_name);
         if let Err(err) = self.try_start_container().await {
             self.sender().send_error(err.to_string())?;
             self.try_remove_container().await?;
@@ -274,6 +293,7 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn do_active(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Image] `do_active` {}", self.inner.image_name);
         if !self.should_be_active() || self.should_be_restarted() {
             self.status.set(Status::CleanDangling);
         }
@@ -281,10 +301,15 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
     }
 
     async fn do_wait_container_started(&mut self) -> Result<(), Error> {
+        log::trace!(
+            "[Update event: Image] `do_wait_container_started` {}",
+            self.inner.image_name
+        );
         Ok(())
     }
 
     async fn do_drop_image(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Image] `do_drop_image` {}", self.inner.image_name);
         self.try_remove_image().await
     }
 }

--- a/libs/sdm/src/network/task/update.rs
+++ b/libs/sdm/src/network/task/update.rs
@@ -40,12 +40,14 @@ impl<C: ManagedProtocol> TaskContext<NetworkTask<C>> {
     }
 
     async fn do_initial_state(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Network] `do_initial_state`");
         self.update_task_status(TaskStatus::Inactive)?;
         self.status.set(Status::Cleanup);
         Ok(())
     }
 
     async fn do_cleanup(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Network] `do_cleanup`");
         if self.network_exists().await {
             self.try_remove_network().await?;
             self.status.set(Status::WaitRemoving);
@@ -58,10 +60,12 @@ impl<C: ManagedProtocol> TaskContext<NetworkTask<C>> {
     }
 
     async fn do_wait_removing(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Network] `do_wait_removing`");
         Ok(())
     }
 
     async fn do_inactive(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Network] `do_inactive`");
         if self.should_be_active() {
             self.try_create_network().await?;
             self.status.set(Status::WaitCreating);
@@ -71,10 +75,12 @@ impl<C: ManagedProtocol> TaskContext<NetworkTask<C>> {
     }
 
     async fn do_wait_creating(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Network] `do_wait_creating`");
         Ok(())
     }
 
     async fn do_active(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Network] `do_active`");
         if !self.should_be_active() {
             self.status.set(Status::Cleanup);
         }

--- a/libs/sdm/src/task.rs
+++ b/libs/sdm/src/task.rs
@@ -249,7 +249,6 @@ where
             requests_receiver: Some(req_rx),
             requests_sender: req_tx,
             context,
-            // next_update: Instant::now(),
             dependencies,
             ready_to_use: false,
         }

--- a/libs/sdm/src/volume/task/update.rs
+++ b/libs/sdm/src/volume/task/update.rs
@@ -38,12 +38,14 @@ impl<C: ManagedProtocol> TaskContext<VolumeTask<C>> {
     }
 
     async fn do_initial_state(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Volume] `do_initial_state`");
         self.update_task_status(TaskStatus::Inactive)?;
         self.status.set(Status::Checking);
         Ok(())
     }
 
     async fn do_checking(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Volume] `do_checking`");
         if self.volume_exists().await {
             self.status.set(Status::Active);
             self.update_task_status(TaskStatus::Active)?;
@@ -56,10 +58,12 @@ impl<C: ManagedProtocol> TaskContext<VolumeTask<C>> {
     }
 
     async fn do_wait_creating(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Volume] `do_wait_creating`");
         Ok(())
     }
 
     async fn do_active(&mut self) -> Result<(), Error> {
+        log::trace!("[Update event: Volume] `do_active`");
         if !self.should_be_active() {
             // self.status.set(Status::Checking);
         }


### PR DESCRIPTION
Description
---
- Removed the spinlock in the update loop in `tari-launchpad/libs/sdm/src/task.rs::update`. Events are being processed correctly and this is not required. 
- Added a bunch of trace logs to monitor the continued operation.

_**Note:** The spinlock was pointed out by @stringhandler_.

Motivation and Context
---
The spin lock unnecessarily kept the system busy during shutdown.

How Has This Been Tested?
---
System-level testing:
- Start-then-stop-when-fully-active of all components works fine.
- Shutting down the application while all components are fully active works fine.
