### PR TITLE
fix: header sync and lingering volumes

### DIFF
--- a/libs/protocol/src/container.rs
+++ b/libs/protocol/src/container.rs
@@ -123,6 +123,12 @@ impl TaskProgress {
     }
 }
 
+impl fmt::Display for TaskProgress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} 0 {}%", self.stage, self.pct)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TaskStatus {
     Inactive,

--- a/libs/sdm/src/image/task/docker.rs
+++ b/libs/sdm/src/image/task/docker.rs
@@ -193,6 +193,7 @@ impl<C: ManagedProtocol> TaskContext<ImageTask<C>> {
             volumes: Some(volumes),
             cmd: Some(args.build()),
             host_config: Some(HostConfig {
+                auto_remove: Some(true),
                 binds: Some(vec![]),
                 network_mode: Some("bridge".to_string()),
                 port_bindings: Some(ports_map(&ports)),


### PR DESCRIPTION
Description
---
- Show header sync status
- Cleanup anonymous volumes that some containers (tor 👀) leave lingering after shutdown

Motivation and Context
---
No lingering volumes and more accurate setup.

How Has This Been Tested?
---
Manually
