### PR TITLE
feat: add mining threads user control

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_launchpad"
 version = "1.6.0"
-description = "A unified user interface for a Tari node, wallet and miner, with a focus on ease-of-use and UX."
+description = "A unified user interface for a Tari node and miner, with a focus on ease-of-use and UX."
 authors = ["The Tari Development Community"]
 license = "BSD-3-Clause"
 repository = "https://github.com/tari-project/tari-launchpad"

--- a/backend/assets/config.toml
+++ b/backend/assets/config.toml
@@ -66,44 +66,10 @@ dns_seeds = ["seeds.stagenet.tari.com"]
 # Custom specified peer seed nodes
 peer_seeds = []
 
-[wallet]
-override_from = "stagenet"
-db_file = "wallet/wallet.dat"
-grpc_enabled = true
-grpc_address = "/ip4/0.0.0.0/tcp/18143"
-password = "tari"
-use_libtor = false
-#gRPC authentication method (default = "none")
-#grpc_authentication = { username = "admin", password = "xxxx" }
-
-# A custom base node peer that will be used to obtain metadata from, example
-# "0eefb45a4de9484eca74846a4f47d2c8d38e76be1fec63b0112bd00d297c0928::/ip4/13.40.98.39/tcp/18189"
-# This is set internally by launchpad when the base node starts
-# custom_base_node = "none"
-
-[wallet.p2p]
-
-[wallet.p2p.transport]
-type = "tor"
-
-[wallet.p2p.transport.tor]
-control_auth = "password=tari"
-socks_address_override = "/dns4/tor/tcp/9050"
-control_address = "/dns4/tor/tcp/9051"
-# When these peer addresses are encountered when dialing another peer, the tor proxy is bypassed and the connection is
-# made directly over TCP. /ip4, /ip6, /dns, /dns4 and /dns6 are supported. (e.g. ["/dns4/my-foo-base-node/tcp/9998"])
-proxy_bypass_addresses = ["/dns4/wallet/tcp/18188"]
-proxy_bypass_for_outbound_tcp = true
-
-[wallet.p2p.transport.tcp]
-#listener_address = "/dns4/wallet/tcp/18188"
-listener_address = "/dns4/wallet/tcp/18188"
-
 [miner]
 base_node_grpc_address = "/dns4/base_node/tcp/18142"
 wallet_grpc_address = "/dns4/wallet/tcp/18143"
 mine_on_tip_only = true
-num_mining_threads = 4
 
 [merge_mining_proxy]
 monerod_url = [ # stagenet

--- a/backend/assets/log4rs.yml
+++ b/backend/assets/log4rs.yml
@@ -89,11 +89,6 @@ loggers:
     appenders:
       - core
     additive: false
-  wallet:
-    level: info
-    appenders:
-      - core
-    additive: false
   tari_miner:
     level: debug
     appenders:

--- a/backend/tauri.conf.json
+++ b/backend/tauri.conf.json
@@ -11,7 +11,7 @@
   },
   "tauri": {
     "cli": {
-      "description": "A simple single-click UI to launch a Tari node, wallet and miner",
+      "description": "A simple single-click UI to launch a Tari node and miner",
       "args": [
         {
           "short": "c",

--- a/cli/src/component/mod.rs
+++ b/cli/src/component/mod.rs
@@ -31,6 +31,7 @@ mod settings;
 mod tabs;
 mod termination;
 mod widgets;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use derive_more::From;
 pub use main_view::MainView;

--- a/cli/src/component/settings/mining.rs
+++ b/cli/src/component/settings/mining.rs
@@ -40,10 +40,12 @@ use crate::{
         AppState,
     },
 };
+use tari_launchpad_protocol::OptionUsizeWrapper;
 
 pub static MINING_SETTINGS: Focus = focus_id!();
 static MONERO_ADDRESS: Focus = focus_id!();
 static SHA_THREADS: Focus = focus_id!();
+static RANDOM_X_THREADS: Focus = focus_id!();
 static MONERO_URL: Focus = focus_id!();
 static WALLET_PAYMENT_ADDRESS: Focus = focus_id!();
 
@@ -51,7 +53,8 @@ pub struct MiningSettings {
     expert_sep: Separator,
     monero_address: LabeledInput,
     monero_url: LabeledInput,
-    sha_threads: LabeledInput<usize>,
+    random_x_threads: LabeledInput<OptionUsizeWrapper>,
+    sha3_threads: LabeledInput<usize>,
     wallet_payment_address: LabeledInput,
 }
 
@@ -61,7 +64,8 @@ impl MiningSettings {
             expert_sep: Separator::new("Expert", []),
             monero_address: LabeledInput::new("Monero mining address", MONERO_ADDRESS),
             monero_url: LabeledInput::new("Monero node URL", MONERO_URL),
-            sha_threads: LabeledInput::new_with_value("SHA3 threads", SHA_THREADS, 2),
+            random_x_threads: LabeledInput::new("RandomX threads", RANDOM_X_THREADS),
+            sha3_threads: LabeledInput::new_with_value("SHA3 threads", SHA_THREADS, 8),
             wallet_payment_address: LabeledInput::new("Wallet payment address", WALLET_PAYMENT_ADDRESS),
         }
     }
@@ -77,8 +81,12 @@ impl MiningSettings {
                 saved_settings.set_monero_mining_address(addr);
                 should_write = true;
             }
-            if let Some(v) = self.sha_threads.fetch_new_value() {
-                saved_settings.set_num_mining_threads(*v);
+            if let Some(v) = self.random_x_threads.fetch_new_value() {
+                saved_settings.set_random_x_num_mining_threads(v.clone());
+                should_write = true;
+            }
+            if let Some(v) = self.sha3_threads.fetch_new_value() {
+                saved_settings.set_sha3_num_mining_threads(*v);
                 should_write = true;
             }
             if let Some(v) = self.wallet_payment_address.fetch_new_value() {
@@ -97,12 +105,18 @@ impl MiningSettings {
 impl Input for MiningSettings {
     type Output = ();
 
+    #[allow(clippy::too_many_lines)]
     fn on_event(&mut self, event: ComponentEvent, state: &mut AppState) -> Option<Self::Output> {
         if let ComponentEvent::StateChanged = event {
             if let Some(settings) = &state.state.config.settings {
                 if let Some(conf) = &settings.saved_settings.xmrig {
                     let value = conf.monero_mining_address.clone();
                     self.monero_address.set(value);
+                }
+                if let Some(num) = &settings.saved_settings.xmrig {
+                    if let Some(value) = num.num_mining_threads.clone() {
+                        self.random_x_threads.set(value);
+                    }
                 }
                 if let Some(conf) = &settings.saved_settings.mm_proxy {
                     let value = conf.monerod_url.clone();
@@ -112,6 +126,10 @@ impl Input for MiningSettings {
                     if let Some(wallet_payment_address) = &conf.wallet_payment_address {
                         self.wallet_payment_address.set(wallet_payment_address.to_string());
                     }
+                }
+                if let Some(num) = &settings.saved_settings.sha3_miner {
+                    let value = num.num_mining_threads;
+                    self.sha3_threads.set(value);
                 }
             }
             return None;
@@ -141,7 +159,7 @@ impl Input for MiningSettings {
                 },
             }
         } else if state.focus_on == SHA_THREADS {
-            let released = self.sha_threads.is_released();
+            let released = self.sha3_threads.is_released();
             match event.pass() {
                 Pass::Leave if released => {
                     state.focus_on(MINING_SETTINGS);
@@ -150,10 +168,26 @@ impl Input for MiningSettings {
                     state.focus_on(MONERO_ADDRESS);
                 },
                 Pass::Down if released => {
+                    state.focus_on(RANDOM_X_THREADS);
+                },
+                _ => {
+                    self.sha3_threads.on_event(event, state);
+                },
+            }
+        } else if state.focus_on == RANDOM_X_THREADS {
+            let released = self.random_x_threads.is_released();
+            match event.pass() {
+                Pass::Leave if released => {
+                    state.focus_on(MINING_SETTINGS);
+                },
+                Pass::Up if released => {
+                    state.focus_on(SHA_THREADS);
+                },
+                Pass::Down if released => {
                     state.focus_on(MONERO_URL);
                 },
                 _ => {
-                    self.sha_threads.on_event(event, state);
+                    self.random_x_threads.on_event(event, state);
                 },
             }
         } else if state.focus_on == MONERO_URL {
@@ -209,6 +243,7 @@ impl<B: Backend> Component<B> for MiningSettings {
             Constraint::Length(3),
             Constraint::Length(3),
             Constraint::Length(3),
+            Constraint::Length(3),
             Constraint::Min(0),
         ];
         let chunks = Layout::default()
@@ -219,8 +254,9 @@ impl<B: Backend> Component<B> for MiningSettings {
             .split(inner_rect);
         self.expert_sep.draw(f, chunks[0], state);
         self.monero_address.draw(f, chunks[1], state);
-        self.sha_threads.draw(f, chunks[2], state);
-        self.monero_url.draw(f, chunks[3], state);
-        self.wallet_payment_address.draw(f, chunks[4], state);
+        self.sha3_threads.draw(f, chunks[2], state);
+        self.random_x_threads.draw(f, chunks[3], state);
+        self.monero_url.draw(f, chunks[4], state);
+        self.wallet_payment_address.draw(f, chunks[5], state);
     }
 }

--- a/cli/src/state/mod.rs
+++ b/cli/src/state/mod.rs
@@ -120,7 +120,7 @@ impl AppState {
                                  configured",
                             )
                         })?;
-                    let action = Action::Action(LaunchpadAction::SaveSettings(settings));
+                    let action = Action::Action(LaunchpadAction::SaveSettings(Box::new(settings)));
                     self.bus_tx.send(action)?;
                 },
             }

--- a/docker_rig/config.toml
+++ b/docker_rig/config.toml
@@ -66,44 +66,10 @@ dns_seeds = ["seeds.stagenet.tari.com"]
 # Custom specified peer seed nodes
 peer_seeds = []
 
-[wallet]
-override_from = "stagenet"
-db_file = "wallet/wallet.dat"
-grpc_enabled = true
-grpc_address = "/ip4/0.0.0.0/tcp/18143"
-password = "tari"
-use_libtor = false
-#gRPC authentication method (default = "none")
-#grpc_authentication = { username = "admin", password = "xxxx" }
-
-# A custom base node peer that will be used to obtain metadata from, example
-# "0eefb45a4de9484eca74846a4f47d2c8d38e76be1fec63b0112bd00d297c0928::/ip4/13.40.98.39/tcp/18189"
-# This is set internally by launchpad when the base node starts
-# custom_base_node = "none"
-
-[wallet.p2p]
-
-[wallet.p2p.transport]
-type = "tor"
-
-[wallet.p2p.transport.tor]
-control_auth = "password=tari"
-socks_address_override = "/dns4/tor/tcp/9050"
-control_address = "/dns4/tor/tcp/9051"
-# When these peer addresses are encountered when dialing another peer, the tor proxy is bypassed and the connection is
-# made directly over TCP. /ip4, /ip6, /dns, /dns4 and /dns6 are supported. (e.g. ["/dns4/my-foo-base-node/tcp/9998"])
-proxy_bypass_addresses = ["/dns4/wallet/tcp/18188"]
-proxy_bypass_for_outbound_tcp = true
-
-[wallet.p2p.transport.tcp]
-#listener_address = "/dns4/wallet/tcp/18188"
-listener_address = "/dns4/wallet/tcp/18188"
-
 [miner]
 base_node_grpc_address = "/dns4/base_node/tcp/18142"
 wallet_grpc_address = "/dns4/wallet/tcp/18143"
 mine_on_tip_only = true
-num_mining_threads = 4
 
 [merge_mining_proxy]
 monerod_url = [ # stagenet

--- a/docker_rig/docker-compose.yml
+++ b/docker_rig/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       APP_EXEC: tari_base_node
       WAIT_FOR_TOR: ${WAIT_FOR_TOR:-0}
       TARI_NETWORK: ${TARI_NETWORK}
-      TARI_DIBBLER__BASE_NODE__DATA_DIR: "/blockchain/dibbler"
     ports:
       - 18189:18189
       - 18142:18142

--- a/docker_rig/xmrig.Dockerfile
+++ b/docker_rig/xmrig.Dockerfile
@@ -55,16 +55,4 @@ ENV dockerfile_version=$VERSION
 ENV dockerfile_build_arch=$BUILDPLATFORM
 ENV xmrig_version=$XMRIG_VERSION
 
-RUN echo -e "\
-{\
-    \"autosave\": true,\
-    \"cpu\": true,\
-    \"opencl\": false,\
-    \"cuda\": false,\
-    \"pools\": [ \
-    { \"coin\": \"monero\", \"url\": \"127.0.0.1:18081\", \"user\": \"44\", \"daemon\": true }\
-    ]\
-}\
-" > /home/tari/.xmrig.json
-
 ENTRYPOINT [ "/usr/local/bin/xmrig" ]

--- a/gui-react/package.json
+++ b/gui-react/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "private": true,
   "license": "BSD-3-Clause",
-  "description": "A simple single-click UI to launch a Tari node, wallet and miner",
+  "description": "A simple single-click UI to launch a Tari node and miner",
   "dependencies": {
     "@headlessui/react": "^1.5.0",
     "@nivo/bar": "^0.79.1",

--- a/libs/protocol/src/launchpad.rs
+++ b/libs/protocol/src/launchpad.rs
@@ -46,7 +46,7 @@ pub enum Action {
 pub enum LaunchpadAction {
     Connect,
     ChangeSession(LaunchpadSession),
-    SaveSettings(PersistentSettings),
+    SaveSettings(Box<PersistentSettings>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/libs/protocol/src/lib.rs
+++ b/libs/protocol/src/lib.rs
@@ -21,6 +21,9 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
 pub mod config;
 pub mod container;
 pub mod errors;
@@ -37,3 +40,28 @@ pub mod tari_format;
 
 pub const ACTIONS: &str = "tari://actions";
 pub const REACTIONS: &str = "tari://reactions";
+
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone, Default)]
+pub struct OptionUsizeWrapper(pub Option<usize>);
+
+// Implement FromStr for the newtype wrapper
+impl FromStr for OptionUsizeWrapper {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            Ok(OptionUsizeWrapper(Some(0)))
+        } else {
+            s.parse().map(|num| OptionUsizeWrapper(Some(num)))
+        }
+    }
+}
+
+impl std::fmt::Display for OptionUsizeWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(value) => write!(f, "{}", value),
+            None => write!(f, ""),
+        }
+    }
+}

--- a/libs/protocol/src/settings.rs
+++ b/libs/protocol/src/settings.rs
@@ -23,7 +23,7 @@
 
 use crate::OptionUsizeWrapper;
 use serde::{Deserialize, Serialize};
-use std::{path::PathBuf, str::FromStr};
+use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]

--- a/libs/protocol/src/settings.rs
+++ b/libs/protocol/src/settings.rs
@@ -21,9 +21,9 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-use std::path::PathBuf;
-
+use crate::OptionUsizeWrapper;
 use serde::{Deserialize, Serialize};
+use std::{path::PathBuf, str::FromStr};
 use thiserror::Error;
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -36,6 +36,8 @@ pub struct BaseNodeConfig {
 pub struct XmRigConfig {
     /// The address that will accept Monero mining rewards
     pub monero_mining_address: String,
+    /// The number of mining threads to employ
+    pub num_mining_threads: Option<OptionUsizeWrapper>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -116,7 +118,16 @@ impl PersistentSettings {
         }
     }
 
-    pub fn set_num_mining_threads(&mut self, num_threads: usize) {
+    pub fn set_random_x_num_mining_threads(&mut self, num_threads: OptionUsizeWrapper) {
+        if self.xmrig.is_none() {
+            self.new_xmrig_settings();
+        }
+        if let Some(x) = self.xmrig.as_mut() {
+            x.num_mining_threads = Some(num_threads)
+        }
+    }
+
+    pub fn set_sha3_num_mining_threads(&mut self, num_threads: usize) {
         if self.sha3_miner.is_none() {
             self.new_sha3_miner_settings();
         }

--- a/libs/sdm-assets/assets/config.toml
+++ b/libs/sdm-assets/assets/config.toml
@@ -84,7 +84,6 @@ use_libtor = false
 [miner]
 base_node_grpc_address = "/dns4/base_node/tcp/18142"
 mine_on_tip_only = true
-num_mining_threads = 4
 
 [merge_mining_proxy]
 monerod_url = [ # mainnet

--- a/libs/sdm-assets/assets/log4rs.yml
+++ b/libs/sdm-assets/assets/log4rs.yml
@@ -89,11 +89,6 @@ loggers:
     appenders:
       - core
     additive: false
-  wallet:
-    level: info
-    appenders:
-      - core
-    additive: false
   tari_miner:
     level: debug
     appenders:

--- a/libs/sdm-assets/assets/settings.toml
+++ b/libs/sdm-assets/assets/settings.toml
@@ -5,7 +5,7 @@ tari_network = "Nextnet"
 interactive = false
 
 [sha3_miner]
-num_mining_threads = 1
+num_mining_threads = 8
 
 [mm_proxy]
 # You can specify multiple monerod instances here, separated by commas
@@ -17,3 +17,5 @@ monero_use_auth = false
 [xmrig]
 # Replace this with your own Monero wallet address (example from https://www.getmonero.org/2021/06/24/general-fund-2020-2021-report.html)
 monero_mining_address = "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A"
+# No value or a value of 0 will let XMRig use auto config, otherwise the provided value will be used
+#num_mining_threads = 0

--- a/libs/sdm-assets/src/configurator.rs
+++ b/libs/sdm-assets/src/configurator.rs
@@ -138,7 +138,6 @@ impl Configurator {
         // images
         self.create_sub_dir(&base_dir, "tor").await?;
         self.create_sub_dir(&base_dir, "base_node").await?;
-        self.create_sub_dir(&base_dir, "wallet").await?;
         self.create_sub_dir(&base_dir, "xmrig").await?;
         self.create_sub_dir(&base_dir, "sha3_miner").await?;
         self.create_sub_dir(&base_dir, "mm_proxy").await?;

--- a/libs/sdm-launchpad/src/bus.rs
+++ b/libs/sdm-launchpad/src/bus.rs
@@ -235,7 +235,7 @@ impl LaunchpadWorker {
         path.push("config");
         path.push("settings.toml");
         debug!("Stored settings: {new_settings:?}");
-        let data = toml::to_string(&new_settings).unwrap();
+        let data = toml::to_string(&new_settings).map_err(|e| Error::msg(format!("Can't save the settings: {e}")))?;
         tokio::fs::write(path, data).await?;
         if let Some(settings) = self.state.config.settings.as_mut() {
             // We just checked that this exists above

--- a/libs/sdm-launchpad/src/bus.rs
+++ b/libs/sdm-launchpad/src/bus.rs
@@ -191,7 +191,7 @@ impl LaunchpadWorker {
                 self.scope.set_config(Some(config))?;
             },
             LaunchpadAction::SaveSettings(settings) => {
-                self.save_settings(settings).await?;
+                self.save_settings(*settings).await?;
             },
         }
         Ok(())

--- a/libs/sdm-launchpad/src/resources/images/l1_tor.rs
+++ b/libs/sdm-launchpad/src/resources/images/l1_tor.rs
@@ -68,6 +68,10 @@ impl ManagedContainer for Tor {
         "tor"
     }
 
+    fn tag(&self) -> &str {
+        "latest-nextnet"
+    }
+
     fn reconfigure(&mut self, config: Option<&LaunchpadConfig>) -> Option<bool> {
         debug!("Reconfiguring Tor");
         self.settings = ConnectionSettings::try_extract(config?);

--- a/libs/sdm-launchpad/src/resources/images/l3_miner.rs
+++ b/libs/sdm-launchpad/src/resources/images/l3_miner.rs
@@ -40,6 +40,7 @@ use tari_sdm::{
 pub struct TariSha3Miner {
     settings: Option<ConnectionSettings>,
     wallet_payment_address: Option<TariAddress>,
+    num_mining_threads: Option<usize>,
 }
 
 impl ManagedTask for TariSha3Miner {
@@ -71,20 +72,23 @@ impl ManagedContainer for TariSha3Miner {
         self.settings = ConnectionSettings::try_extract(config?);
         let session = &self.settings.as_ref()?.session;
 
-        self.wallet_payment_address = match config?.settings {
+        (self.wallet_payment_address, self.num_mining_threads) = match config?.settings {
             Some(ref settings) if settings.saved_settings.sha3_miner.is_none() => {
                 info!("No Sha3 Miner settings found for the container configuration. Falling back on defaults.");
-                None
+                (None, None)
             },
-            Some(ref settings) => settings
+            Some(ref settings) => (
+                settings
                 .saved_settings
                 .sha3_miner
                 .clone()?
                 .wallet_payment_address
                 .and_then(|s| TariAddress::from_str(&s).ok()),
+                Some(settings.saved_settings.sha3_miner.clone()?.num_mining_threads),
+            ),
             None => {
                 warn!("The settings configuration for the Sha3 Miner config is empty");
-                None
+                (None, None)
             },
         };
 
@@ -98,7 +102,11 @@ impl ManagedContainer for TariSha3Miner {
     fn envs(&self, envs: &mut Envs) {
         if let Some(settings) = self.settings.as_ref() {
             settings.add_common(envs);
-            envs.set("TARI_MINER__NUM_MINING_THREADS", 8); // TODO: Get config num
+            if let Some(value) = self.num_mining_threads.as_ref() {
+                envs.set("TARI_MINER__NUM_MINING_THREADS", value);
+            } else {
+                envs.set("TARI_MINER__NUM_MINING_THREADS", 8);
+            }
             envs.set("TARI_MINER__MINE_ON_TIP_ONLY", 1);
             envs.set(
                 &format!(

--- a/libs/sdm-launchpad/src/resources/images/l3_miner.rs
+++ b/libs/sdm-launchpad/src/resources/images/l3_miner.rs
@@ -79,11 +79,11 @@ impl ManagedContainer for TariSha3Miner {
             },
             Some(ref settings) => (
                 settings
-                .saved_settings
-                .sha3_miner
-                .clone()?
-                .wallet_payment_address
-                .and_then(|s| TariAddress::from_str(&s).ok()),
+                    .saved_settings
+                    .sha3_miner
+                    .clone()?
+                    .wallet_payment_address
+                    .and_then(|s| TariAddress::from_str(&s).ok()),
                 Some(settings.saved_settings.sha3_miner.clone()?.num_mining_threads),
             ),
             None => {

--- a/ui/backend/tauri.conf.json
+++ b/ui/backend/tauri.conf.json
@@ -11,7 +11,7 @@
   },
   "tauri": {
     "cli": {
-      "description": "A simple single-click UI to launch a Tari node, wallet and miner",
+      "description": "A simple single-click UI to launch a Tari node and miner",
       "args": [
         {
           "short": "c",


### PR DESCRIPTION
Description
---
Completed wiring of mining SHA3 and RandomX mining threads into the backend cntainers as this was not implemented fully.

**Note:** Setting the number of XMRig threads has no effect at this time; it may start to work when the new XMRig Docker image is generated as this default user config file will have been removed:

![image](https://github.com/tari-project/tari-launchpad/assets/39146854/d990729c-a54d-46ec-88ac-023e617c026a)

The Docker console screen capture below illustrates that XMRig are started with the correct parameters, but that it has no effect.
```
/ $ top

Mem: 12756268K used, 19955696K free, 37196K shrd, 1184488K buff, 5864140K cached
CPU:  99% usr   0% sys   0% nic   0% idle   0% io   0% irq   0% sirq
Load average: 15.81 18.38 16.62 22/1051 65
  PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
    1     0 tari     S    2408m   7%   7  56% /usr/local/bin/xmrig --config=/dev/null --url=tari_mm_proxy:18081 --user=${TARI_MONERO_WALLET_ADDRESS} --coin=monero --daemon --log-file=/home/tari/xmrig.log --verbose --threads=${TARI_RANDOM_X_NUM_MINING_THREADS} --asm=auto
   57     0 tari     S     1668   0%  19   0% /bin/sh
   65    57 tari     R     1596   0%   4   0% top
/ $ 

/ $ echo /usr/local/bin/xmrig --config=/dev/null --url=tari_mm_proxy:18081 --user=${TARI_MONERO_WALLET_ADDRESS} --coin=monero --daemon --log-file=/home/tari/xmrig.log --verbose --threads=${TARI_RANDOM_X_NUM_MINING_THREADS} --asm=auto
/usr/local/bin/xmrig --config=/dev/null --url=tari_mm_proxy:18081 --user=489r43gR8bDMJNBf4Q6sL9CNERvZQrTqjRCSESqgWQEWWq2UGAfj2voaw3zBtD7U8CQ391Nc1PDHUHiN85yhbZnCDasqzyX --coin=monero --daemon --log-file=/home/tari/xmrig.log --verbose --threads=4 --asm=auto
/ $ 
```
```
2024-02-16 13:09:20 [2024-02-16 11:09:20.243] 
2024-02-16 13:09:20 [2024-02-16 11:09:20.243] ^
2024-02-16 13:09:20 [2024-02-16 11:09:20.243] /dev/null<line:1, position:1>: "The document is empty."
2024-02-16 13:09:20  * ABOUT        XMRig/6.21.0 gcc/12.2.1 (built for Linux x86-64, 64 bit)
2024-02-16 13:09:20  * LIBS         libuv/1.44.2 OpenSSL/1.1.1s hwloc/2.9.0
2024-02-16 13:09:20  * HUGE PAGES   supported
2024-02-16 13:09:20  * 1GB PAGES    disabled
2024-02-16 13:09:20  * CPU          12th Gen Intel(R) Core(TM) i7-12700H (1) 64-bit AES VM
2024-02-16 13:09:20                 L2:12.5 MB L3:24.0 MB 10C/20T NUMA:1
2024-02-16 13:09:20  * MEMORY       2.0/31.2 GB (6%)
2024-02-16 13:09:20  * DONATE       1%
2024-02-16 13:09:20  * ASSEMBLY     auto:intel
2024-02-16 13:09:20  * POOL #1      tari_mm_proxy:18081 coin Monero
2024-02-16 13:09:20  * COMMANDS     hashrate, pause, resume, results, connection
2024-02-16 13:09:21 [2024-02-16 11:09:21.717]  net      use daemon tari_mm_proxy:18081  192.168.80.4
2024-02-16 13:09:21 [2024-02-16 11:09:21.717]  net      new job from tari_mm_proxy:18081 diff 29301K algo rx/0 height 3085453 (55 tx)
2024-02-16 13:09:21 [2024-02-16 11:09:21.717]  cpu      use argon2 implementation AVX2
2024-02-16 13:09:21 [2024-02-16 11:09:21.718]  msr      msr kernel module is not available
2024-02-16 13:09:21 [2024-02-16 11:09:21.718]  msr      FAILED TO APPLY MSR MOD, HASHRATE WILL BE LOW
2024-02-16 13:09:21 [2024-02-16 11:09:21.718]  randomx  init dataset algo rx/0 (20 threads) seed 649517a9399403f7...
2024-02-16 13:09:21 [2024-02-16 11:09:21.718]  randomx  allocated 2336 MB (2080+256) huge pages 0% 0/1168 +JIT (0 ms)
2024-02-16 13:09:24 [2024-02-16 11:09:24.188]  randomx  dataset ready (2470 ms)
2024-02-16 13:09:24 [2024-02-16 11:09:24.188]  cpu      use profile  rx  (12 threads) scratchpad 2048 KB
2024-02-16 13:09:24 [2024-02-16 11:09:24.196]  cpu      READY threads 12/12 (12) huge pages 100% 12/12 memory 24576 KB (7 ms)
2024-02-16 13:09:38 [2024-02-16 11:09:38.160]  net      new job from tari_mm_proxy:18081 diff 29301K algo rx/0 height 3085453 (59 tx)
2024-02-16 13:09:54 [2024-02-16 11:09:54.167]  net      new job from tari_mm_proxy:18081 diff 29301K algo rx/0 height 3085453 (64 tx)
2024-02-16 13:10:10 [2024-02-16 11:10:10.153]  net      new job from tari_mm_proxy:18081 diff 29301K algo rx/0 height 3085453 (68 tx)
2024-02-16 13:10:24 [2024-02-16 11:10:24.232]  miner    speed 10s/60s/15m 2900.9 n/a n/a H/s max 3298.5 H/s
```

Motivation and Context
---
Users were not able to control the amount of mining threads to use

How Has This Been Tested?
---
System-level testing
