### PR TITLE
ci(fix): use older ubuntu base for cli and fix docker builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.riscv64-unknown-linux-gnueabihf]
+linker = "riscv64-linux-gnueabihf-gcc"

--- a/.github/workflows/build_cli.json
+++ b/.github/workflows/build_cli.json
@@ -1,22 +1,22 @@
 [
   {
     "name": "linux-x86_64",
-    "runs-on": "ubuntu-latest",
+    "runs-on": "ubuntu-20.04",
     "rust": "stable",
     "target": "x86_64-unknown-linux-gnu",
     "cross": false
   },
   {
     "name": "linux-arm64",
-    "runs-on": "ubuntu-latest",
+    "runs-on": "ubuntu-20.04",
     "rust": "stable",
     "target": "aarch64-unknown-linux-gnu",
     "cross": false,
-    "build_enabled": false
+    "build_enabled": true
   },
   {
     "name": "linux-riscv64",
-    "runs-on": "ubuntu-latest",
+    "runs-on": "ubuntu-20.04",
     "rust": "stable",
     "target": "riscv64gc-unknown-linux-gnu",
     "cross": false,

--- a/.github/workflows/build_cli.yml
+++ b/.github/workflows/build_cli.yml
@@ -45,7 +45,7 @@ jobs:
           #
           # build only single target image
           # matrix_selection=$( jq -c '.[] | select( ."name" == "linux-x86_64" )' ${{ env.matrix-json-file }} )
-          # matrix_selection=$( jq -c '.[] | select( ."runs-on" | startswith("macos") )' ${{ env.matrix-json-file }} )
+          # matrix_selection=$( jq -c '.[] | select( ."name" | contains("linux") )' ${{ env.matrix-json-file }} )
           #
           # buid select target images - build_enabled
           matrix_selection=$( jq -c '.[] | select( ."build_enabled" != false )' ${{ env.matrix-json-file }} )
@@ -112,6 +112,12 @@ jobs:
           TARI_NETWORK_VERSION=$(cargo tree -p tari-lp-cli -i tari_core --locked | head -n1 | cut -d " " -f 2)
           echo "TARI_NETWORK_VERSION=${TARI_NETWORK_VERSION}" >> $GITHUB_ENV
           echo "TARI_NETWORK_VERSION=${TARI_NETWORK_VERSION}" >> $GITHUB_OUTPUT
+          TARI_BUILD_ISA_CPU=${{ matrix.builds.target }}
+          # Strip unknown part
+          TARI_BUILD_ISA_CPU=${TARI_BUILD_ISA_CPU//-unknown-linux-gnu}
+          # Strip gc used by rust
+          TARI_BUILD_ISA_CPU=${TARI_BUILD_ISA_CPU//gc}
+          echo "TARI_BUILD_ISA_CPU=${TARI_BUILD_ISA_CPU}" >> $GITHUB_ENV
 
       - name: Install Linux dependencies - Ubuntu
         if: ${{ startsWith(runner.os,'Linux') && ( ! matrix.builds.cross ) }}
@@ -120,12 +126,14 @@ jobs:
           sudo bash scripts/cli/install_ubuntu_dependencies.sh
           sudo bash scripts/install_ubuntu_dependencies.sh
 
-      - name: Install Linux dependencies - Ubuntu - cross-compile arm64 on x86-64
-        if: ${{ startsWith(runner.os,'Linux') && ( ! matrix.builds.cross ) && matrix.builds.name == 'linux-arm64' }}
+      - name: Install Linux dependencies - Ubuntu - cross-compiled ${{ env.TARI_BUILD_ISA_CPU }} on x86-64
+        if: ${{ startsWith(runner.os,'Linux') && ( ! matrix.builds.cross ) && matrix.builds.name != 'linux-x86_64' }}
         run: |
           sudo apt-get update
-          sudo bash scripts/cli/install_ubuntu_dependencies-arm64.sh
+          sudo bash scripts/cli/install_ubuntu_dependencies-cross_compile.sh ${{ env.TARI_BUILD_ISA_CPU }}
+          sudo bash scripts/install_ubuntu_dependencies.sh
           rustup target add ${{ matrix.builds.target }}
+          echo "PKG_CONFIG_SYSROOT_DIR=/usr/${{ env.TARI_BUILD_ISA_CPU }}-linux-gnu/" >> $GITHUB_ENV
 
       - name: Install macOS dependencies
         if: startsWith(runner.os,'macOS')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,6 +3254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.2.3+3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3261,6 +3270,7 @@ checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5562,6 +5572,7 @@ dependencies = [
  "minotari_app_grpc",
  "minotari_node_grpc_client",
  "minotari_wallet_grpc_client",
+ "openssl-sys",
  "regex",
  "serde",
  "serde_json",

--- a/docker_rig/tarilabs.Dockerfile
+++ b/docker_rig/tarilabs.Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.3
 
 # https://hub.docker.com/_/rust
-ARG RUST_VERSION=1.74
+ARG RUST_VERSION=1.76
 ARG OS_BASE=bookworm
 
 # rust source compile with cross platform build support
@@ -50,7 +50,7 @@ COPY infrastructure infrastructure
 COPY meta meta
 COPY buildtools/deps_only buildtools/deps_only
 COPY integration_tests integration_tests
-COPY hash_domains hash_domains
+COPY hashing hashing
 COPY scripts scripts
 
 # Disable Prompt During Packages Installation

--- a/libs/sdm-launchpad/Cargo.toml
+++ b/libs/sdm-launchpad/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.72"
 async-trait = "0.1.72"
 chrono = "0.4.31"
 log = "0.4.19"
+openssl-sys = { version = "0.9", features = ["vendored"] }
 regex = "1.9.1"
 serde = "=1.0.167"
 serde_json = "1.0.103"

--- a/scripts/cli/install_ubuntu_dependencies-arm64.sh
+++ b/scripts/cli/install_ubuntu_dependencies-arm64.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env sh
-#
-# Install Ubuntu aarch64/arm64 deb dev/tool packages on x86_64
-#
-apt-get -y install $* \
-  pkg-config-aarch64-linux-gnu \
-  gcc-aarch64-linux-gnu \
-  g++-aarch64-linux-gnu

--- a/scripts/cli/install_ubuntu_dependencies-cross_compile.sh
+++ b/scripts/cli/install_ubuntu_dependencies-cross_compile.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+#
+# Install Ubuntu aarch64(arm64)/riscv64gc deb dev/tool packages on x86_64
+#
+
+USAGE="Usage: $0 ISA_ARCH other packages"
+
+if [ "$#" == "0" ]; then
+    echo "$USAGE"
+    exit 1
+fi
+
+isa_arch=${1}
+shift
+
+apt-get --assume-yes install $* \
+  pkg-config-${isa_arch}-linux-gnu \
+  gcc-${isa_arch}-linux-gnu \
+  g++-${isa_arch}-linux-gnu


### PR DESCRIPTION
Description
Build with Ubuntu 20.04, so that we support more usage on old Ubuntu installs
Fix change in tari to build docker images
Start of arm64 changes

